### PR TITLE
fix: Correct Smarty syntax for array assignment in products.tpl

### DIFF
--- a/themes/mundolimpiotheme/templates/_partials/homepage/products.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/products.tpl
@@ -15,28 +15,72 @@
         *}
 
         {* Ejemplo: Mostrar algunas categorías principales *}
+        {* Smarty 3 syntax for associative arrays within assign is `foo=[bar=>'baz']` or more complexly, build step-by-step.
+           For simplicity with complex structures directly in template, consider JSON and then `json_decode` if really needed,
+           or better, prepare in PHP if this were a module.
+           Here, we'll define them more simply for direct use.
+        *}
         <div class="categories-grid">
-            {assign var=category_example_1 value=['name' => {l s='Limpieza del Hogar' d='Shop.Theme.Mundolimpio'}, 'image' => '{$urls.theme_assets}img/placeholders/category-hogar-400x300.png', 'link' => '#link-categoria-hogar', 'subcategories' => [{name:'Cocina', link:'#'}, {name:'Baño', link:'#'}]]}
-            {assign var=category_example_2 value=['name' => {l s='Cuidado Personal' d='Shop.Theme.Mundolimpio'}, 'image' => '{$urls.theme_assets}img/placeholders/category-personal-400x300.png', 'link' => '#link-categoria-personal', 'subcategories' => [{name:'Jabones', link:'#'}, {name:'Champús', link:'#'}]]}
-            {assign var=category_example_3 value=['name' => {l s='Bebés y Niños' d='Shop.Theme.Mundolimpio'}, 'image' => '{$urls.theme_assets}img/placeholders/category-bebes-400x300.png', 'link' => '#link-categoria-bebes', 'subcategories' => []]}
+            {$category_example_1_name = {l s='Limpieza del Hogar' d='Shop.Theme.Mundolimpio'}}
+            {$category_example_1_image = "`$urls.theme_assets`img/placeholders/category-hogar-400x300.png"}
+            {$category_example_1_link = "#link-categoria-hogar"}
+            {$category_example_1_subcategories = [
+                ['name' => {l s='Cocina' d='Shop.Theme.Mundolimpio'}, 'link' => '#'],
+                ['name' => {l s='Baño' d='Shop.Theme.Mundolimpio'}, 'link' => '#']
+            ]}
 
-            {foreach from=[$category_example_1, $category_example_2, $category_example_3] item=category_item}
+            {$category_example_2_name = {l s='Cuidado Personal' d='Shop.Theme.Mundolimpio'}}
+            {$category_example_2_image = "`$urls.theme_assets`img/placeholders/category-personal-400x300.png"}
+            {$category_example_2_link = "#link-categoria-personal"}
+            {$category_example_2_subcategories = [
+                ['name' => {l s='Jabones' d='Shop.Theme.Mundolimpio'}, 'link' => '#'],
+                ['name' => {l s='Champús' d='Shop.Theme.Mundolimpio'}, 'link' => '#']
+            ]}
+
+            {$category_example_3_name = {l s='Bebés y Niños' d='Shop.Theme.Mundolimpio'}}
+            {$category_example_3_image = "`$urls.theme_assets`img/placeholders/category-bebes-400x300.png"}
+            {$category_example_3_link = "#link-categoria-bebes"}
+            {$category_example_3_subcategories = []}
+
+            {* Now create an array of these structures *}
+            {assign var="category_examples" value=[
+                [
+                    'name' => $category_example_1_name,
+                    'image' => $category_example_1_image,
+                    'link' => $category_example_1_link,
+                    'subcategories' => $category_example_1_subcategories
+                ],
+                [
+                    'name' => $category_example_2_name,
+                    'image' => $category_example_2_image,
+                    'link' => $category_example_2_link,
+                    'subcategories' => $category_example_2_subcategories
+                ],
+                [
+                    'name' => $category_example_3_name,
+                    'image' => $category_example_3_image,
+                    'link' => $category_example_3_link,
+                    'subcategories' => $category_example_3_subcategories
+                ]
+            ]}
+
+            {foreach from=$category_examples item=category_item}
                 <div class="category-card ml-animate-on-scroll anim-scaleIn">
                     <div class="category-image">
-                        <a href="{$category_item.link nofilter}">
-                            <img src="{$category_item.image nofilter}" alt="{$category_item.name|escape:'htmlall':'UTF-8'}" class="category-img lazyload">
+                        <a href="{$category_item.link|escape:'htmlall':'UTF-8'}">
+                            <img src="{$category_item.image|escape:'htmlall':'UTF-8'}" alt="{$category_item.name|escape:'htmlall':'UTF-8'}" class="category-img lazyload">
                         </a>
                     </div>
                     <div class="category-content">
-                        <h3 class="category-title"><a href="{$category_item.link nofilter}">{$category_item.name|escape:'htmlall':'UTF-8'}</a></h3>
+                        <h3 class="category-title"><a href="{$category_item.link|escape:'htmlall':'UTF-8'}">{$category_item.name|escape:'htmlall':'UTF-8'}</a></h3>
                         {if $category_item.subcategories}
                             <div class="subcategories">
                                 {foreach from=$category_item.subcategories item=subcategory}
-                                    <a href="{$subcategory.link nofilter}" class="subcategory-link">{$subcategory.name|escape:'htmlall':'UTF-8'}</a>
+                                    <a href="{$subcategory.link|escape:'htmlall':'UTF-8'}" class="subcategory-link">{$subcategory.name|escape:'htmlall':'UTF-8'}</a>
                                 {/foreach}
                             </div>
                         {/if}
-                        <a href="{$category_item.link nofilter}" class="btn btn-outline category-btn">{l s='Ver Productos' d='Shop.Theme.Actions'}</a>
+                        <a href="{$category_item.link|escape:'htmlall':'UTF-8'}" class="btn btn-outline category-btn">{l s='Ver Productos' d='Shop.Theme.Actions'}</a>
                     </div>
                 </div>
             {/foreach}


### PR DESCRIPTION
Addresses a Smarty compiler syntax error in themes/mundolimpiotheme/templates/_partials/homepage/products.tpl.

The previous syntax for assigning complex associative arrays was incorrect for Smarty within a single {assign} block. This change refactors the example category data assignment to be compatible by:
1. Assigning individual properties of example categories to separate Smarty variables.
2. Constructing a main array `$category_examples` using these pre-assigned variables.

This should resolve the "Unexpected ':'" error during template compilation.