### PR TITLE
fix: Prevent TypeError in ecology.tpl by pre-calculating delay

### DIFF
--- a/themes/mundolimpiotheme/templates/_partials/homepage/ecology.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/ecology.tpl
@@ -37,3 +37,8 @@
         </div>
     </div>
 </section>
+
+
+
+
+

--- a/themes/mundolimpiotheme/templates/_partials/homepage/ecology.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/ecology.tpl
@@ -15,8 +15,10 @@
                         ['icon' => 'local_florist', 'text' => {l s='Libre de Crueldad Animal (Cruelty-Free)' d='Shop.Theme.Mundolimpio'}],
                         ['icon' => 'handshake', 'text' => {l s='Apoyo a Comunidades y Comercio Justo' d='Shop.Theme.Mundolimpio'}]
                     ]}
-                    {foreach from=$ecology_points item=point}
-                        <div class="ecology-item ml-animate-on-scroll anim-fadeInLeft" data-delay="{$smarty.foreach.point.iteration * 100}">
+                    {foreach from=$ecology_points item=point name=ecologyLoop}
+                        {* Assign the calculated delay to a variable first to ensure it's treated as a number before being outputted *}
+                        {assign var="animation_delay" value=$smarty.foreach.ecologyLoop.iteration * 100}
+                        <div class="ecology-item ml-animate-on-scroll anim-fadeInLeft" data-delay="{$animation_delay|escape:'htmlall':'UTF-8'}">
                             <i class="material-icons">{$point.icon|escape:'htmlall':'UTF-8'}</i>
                             <span>{$point.text|escape:'htmlall':'UTF-8'}</span>
                         </div>


### PR DESCRIPTION
Addresses a Smarty/PHP TypeError "Unsupported operand types: string * int" that occurred during the rendering of the ecology section.

The error was likely caused by Smarty potentially misinterpreting the type of `\$smarty.foreach.point.iteration` within the `data-delay` attribute expression when directly multiplied.

This fix explicitly assigns the result of the multiplication `\$smarty.foreach.ecologyLoop.iteration * 100` to a new Smarty variable `\$animation_delay` before using it in the `data-delay` attribute. This ensures the calculation is performed numerically and then the result is outputted.

Also added a `name` attribute to the foreach loop for clarity, changing `point` to `ecologyLoop` for `smarty.foreach` properties.