### PR TITLE
fix: Make logo rendering in header.tpl more robust

### DIFF
--- a/themes/mundolimpiotheme/assets/css/custom.css
+++ b/themes/mundolimpiotheme/assets/css/custom.css
@@ -1,0 +1,15 @@
+/* Mundo Limpio Theme - Custom CSS (custom.css) */
+/* ==========================================================================
+   Este archivo es para que el USUARIO FINAL del tema (administrador de la tienda)
+   pueda añadir sus propios estilos CSS sin modificar directamente theme.css.
+   Esto facilita las actualizaciones del tema, ya que theme.css podría ser
+   sobrescrito, pero custom.css no lo será.
+
+   Añade tus reglas CSS personalizadas aquí.
+   Ejemplo:
+   .my-custom-class {
+       color: red !important;
+   }
+   ========================================================================== */
+
+/* No añadas aquí los estilos principales del tema. Usa theme.css para eso. */

--- a/themes/mundolimpiotheme/assets/css/theme.css
+++ b/themes/mundolimpiotheme/assets/css/theme.css
@@ -1,0 +1,369 @@
+/* Mundo Limpio Theme - Main CSS (theme.css) */
+
+/* --------------------------------------------------------------
+   Variables Globales (Defaults - pueden ser sobreescritas por CSS en línea desde header.tpl si es necesario)
+-------------------------------------------------------------- */
+:root {
+    --ml-font-primary: var(--mundolimpio-font-primary, 'Arial', sans-serif);
+    --ml-font-secondary: var(--mundolimpio-font-secondary, 'Arial', sans-serif); /* Para títulos */
+    --ml-color-primary: var(--mundolimpio-color-primary, #667eea);
+    --ml-color-secondary: var(--mundolimpio-color-secondary, #ff6b6b);
+    --ml-color-text: var(--mundolimpio-color-text, #333333);
+    --ml-color-link: var(--mundolimpio-color-link, var(--ml-color-primary));
+    --ml-color-background-light: var(--mundolimpio-color-background-light, #f8f9fa);
+    --ml-color-background-dark: var(--mundolimpio-color-background-dark, #282c34); /* Un gris oscuro más suave */
+    --ml-container-max-width: var(--mundolimpio-container-max-width, 1200px);
+    --ml-base-font-size: var(--mundolimpio-base-font-size, 16px);
+    --ml-heading-font-scale: var(--mundolimpio-heading-font-scale, 1.2);
+    --ml-section-padding-y: var(--mundolimpio-section-padding-y, 60px);
+    --ml-button-border-radius: var(--mundolimpio-button-border-radius, 8px);
+    --ml-card-border-radius: var(--mundolimpio-card-border-radius, 12px); /* Un poco más redondeado */
+
+    --ml-shadow: 0 8px 25px rgba(0,0,0,0.07); /* Sombra más suave */
+    --ml-shadow-hover: 0 12px 30px rgba(0,0,0,0.1);
+    --ml-transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+
+    /* Variables específicas del Header React */
+    --ml-header-height: 80px;
+    --ml-header-height-scrolled: 70px;
+    --ml-header-bg-initial: transparent;
+    --ml-header-bg-scrolled: white;
+    --ml-header-text-initial: white;
+    --ml-header-text-scrolled: var(--ml-color-text);
+    --ml-header-link-hover-initial: var(--ml-corporate-green, #68D391); /* Verde más brillante */
+    --ml-header-link-hover-scrolled: var(--ml-color-primary);
+    --ml-corporate-green: #38A169; /* Un verde corporativo más definido */
+    --ml-corporate-blue: #3182CE; /* Un azul corporativo */
+}
+
+/* --------------------------------------------------------------
+   Resets y Estilos Base
+-------------------------------------------------------------- */
+body {
+    font-family: var(--ml-font-primary);
+    font-size: var(--ml-base-font-size);
+    color: var(--ml-color-text);
+    background-color: #fff;
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+    color: var(--ml-color-link);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+a:hover {
+    color: color-mix(in srgb, var(--ml-color-link) 70%, black);
+    text-decoration: none;
+}
+
+.container {
+    max-width: var(--ml-container-max-width);
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: 100%;
+}
+
+/* --- Header Principal (ml-main-header) --- */
+.ml-main-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1030;
+    transition: background-color 0.35s ease-in-out, box-shadow 0.35s ease-in-out, height 0.35s ease-in-out, padding 0.35s ease-in-out;
+    background-color: var(--ml-header-bg-initial);
+    height: var(--ml-header-height);
+    display: flex; /* Para centrar .header-inner-wrapper verticalmente */
+    align-items: center; /* Para centrar .header-inner-wrapper verticalmente */
+}
+.ml-main-header .header-inner-wrapper { /* Contenedor interno para el contenido del header */
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%; /* Ocupa todo el ancho del .container padre */
+    height: 100%; /* Ocupa toda la altura del .ml-main-header */
+}
+
+/* Estado "scrolled" del header */
+.ml-main-header.is-scrolled {
+    background-color: var(--ml-header-bg-scrolled);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08); /* Sombra más sutil */
+    height: var(--ml-header-height-scrolled);
+    /* border-bottom: 1px solid #e9ecef; */ /* Borde opcional */
+}
+
+/* Logo */
+.ml-main-header .header-logo-container {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0; /* Evita que el logo se encoja */
+}
+.ml-main-header .logo {
+    max-height: calc(var(--ml-header-height) - 28px); /* Ajustar padding (14px arriba y abajo) */
+    width: auto;
+    transition: max-height 0.35s ease-in-out;
+}
+.ml-main-header.is-scrolled .logo {
+    max-height: calc(var(--ml-header-height-scrolled) - 20px); /* Logo más pequeño */
+}
+
+/* Navegación Principal (Desktop) */
+.ml-main-header .header-main-nav {
+    margin-left: auto; /* Empuja el menú hacia la derecha si el CTA está después */
+}
+.ml-main-header .header-main-nav ul#top-menu { /* ps_mainmenu suele usar id #top-menu */
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    gap: clamp(15px, 2.5vw, 30px); /* Espacio entre ítems del menú */
+}
+.ml-main-header .header-main-nav ul#top-menu > li > a {
+    font-family: 'Montserrat', var(--ml-font-primary); /* Especificar Montserrat */
+    text-decoration: none;
+    transition: color 0.25s ease-in-out, opacity 0.25s ease-in-out;
+    color: var(--ml-header-text-initial);
+    font-weight: 500;
+    padding: 5px 0; /* Más sutil para no afectar altura del header */
+    position: relative; /* Para pseudo-elementos de hover/active */
+    font-size: clamp(0.9rem, 1.8vw, 1rem);
+}
+.ml-main-header.is-scrolled .header-main-nav ul#top-menu > li > a {
+    color: var(--ml-header-text-scrolled);
+}
+.ml-main-header .header-main-nav ul#top-menu > li > a:hover {
+    color: var(--ml-header-link-hover-initial);
+    opacity: 0.85;
+}
+.ml-main-header.is-scrolled .header-main-nav ul#top-menu > li > a:hover {
+    color: var(--ml-header-link-hover-scrolled);
+}
+/* Efecto subrayado opcional en hover/active */
+.ml-main-header .header-main-nav ul#top-menu > li > a::after {
+    content: '';
+    position: absolute;
+    bottom: -2px; /* Posición del subrayado */
+    left: 0;
+    width: 0;
+    height: 2px;
+    background-color: var(--ml-header-link-hover-initial);
+    transition: width 0.3s ease;
+}
+.ml-main-header.is-scrolled .header-main-nav ul#top-menu > li > a::after {
+    background-color: var(--ml-header-link-hover-scrolled);
+}
+.ml-main-header .header-main-nav ul#top-menu > li > a:hover::after,
+.ml-main-header .header-main-nav ul#top-menu > li.current > a::after { /* 'current' o la clase que ponga PS */
+    width: 100%;
+}
+
+
+/* Botón CTA en Header */
+.ml-main-header .header-cta-button {
+    margin-left: clamp(20px, 3vw, 40px); /* Espacio desde la navegación */
+}
+.ml-main-header .header-cta-button .btn.ml-contact-btn {
+    background-color: var(--ml-corporate-green);
+    color: white;
+    font-family: 'Montserrat', var(--ml-font-primary);
+    padding: 0.65em 1.4em;
+    font-size: clamp(0.85rem, 1.9vw, 0.95rem);
+    border-color: var(--ml-corporate-green);
+}
+.ml-main-header .header-cta-button .btn.ml-contact-btn:hover {
+    background-color: color-mix(in srgb, var(--ml-corporate-green) 85%, black);
+    border-color: color-mix(in srgb, var(--ml-corporate-green) 85%, black);
+}
+.ml-main-header.is-scrolled .header-cta-button .btn.ml-contact-btn {
+    /* Podría cambiar de color si es necesario con el scroll */
+    /* background-color: var(--ml-corporate-blue); */
+    /* border-color: var(--ml-corporate-blue); */
+}
+
+
+/* --- Menú Móvil --- */
+.mobile-menu-container { /* Contenedor del icono de hamburguesa y otros iconos móviles si los hay */
+    display: none; /* Oculto por defecto, se muestra con media query */
+    align-items: center;
+}
+.js-ml-menu-toggle {
+    background: transparent;
+    border: none;
+    color: var(--ml-header-text-initial);
+    font-size: 2rem;
+    cursor: pointer;
+    padding: 8px; /* Aumentar área de clic */
+    margin-left: 10px;
+    z-index: 1045; /* Por encima del panel de menú */
+    transition: color 0.3s ease, transform 0.3s ease;
+}
+.ml-main-header.is-scrolled .js-ml-menu-toggle {
+    color: var(--ml-header-text-scrolled);
+}
+.js-ml-menu-toggle .material-icons {
+    display: block;
+    transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+.js-ml-menu-toggle.open .material-icons {
+    transform: rotate(90deg);
+}
+
+
+.ml-mobile-nav {
+    position: fixed;
+    top: 0;
+    left: -100%;
+    width: 85%;
+    max-width: 300px; /* Máximo ancho del panel */
+    height: 100vh;
+    background-color: var(--ml-color-background-dark);
+    color: white;
+    padding: var(--ml-header-height-scrolled) 20px 20px; /* Padding superior igual a altura del header scrolleado */
+    box-shadow: 3px 0 15px rgba(0,0,0,0.2);
+    transition: left 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    z-index: 1040;
+    overflow-y: auto;
+    display: none; /* Oculto por defecto, se muestra con media query y JS */
+}
+.ml-mobile-nav.open {
+    left: 0;
+}
+.ml-mobile-nav ul#top-menu { /* Estilos para ps_mainmenu en móvil */
+    flex-direction: column;
+    align-items: flex-start; /* Alinear texto a la izquierda */
+    gap: 0; /* Sin gap, se maneja con padding de <li> */
+}
+.ml-mobile-nav ul#top-menu > li {
+    width: 100%;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+.ml-mobile-nav ul#top-menu > li:last-child {
+    border-bottom: none;
+}
+.ml-mobile-nav ul#top-menu > li > a {
+    display: block;
+    padding: 15px 10px;
+    color: #f0f0f0; /* Texto un poco menos brillante que blanco puro */
+    text-decoration: none;
+    font-size: 1.1rem;
+    font-family: 'Montserrat', var(--ml-font-primary);
+    transition: background-color 0.2s ease, color 0.2s ease;
+    font-weight: 500;
+}
+.ml-mobile-nav ul#top-menu > li > a:hover,
+.ml-mobile-nav ul#top-menu > li.current > a { /* Asumiendo que 'current' es la clase para el ítem activo */
+    background-color: rgba(255,255,255,0.08);
+    color: var(--ml-corporate-green); /* O un color de acento */
+}
+.ml-mobile-nav .mobile-nav-cta {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(255,255,255,0.1);
+}
+.ml-mobile-nav .mobile-nav-cta .btn {
+    width: 100%;
+    text-align: center;
+}
+
+body.mobile-menu-open {
+    overflow: hidden; /* Prevenir scroll del body cuando el menú móvil está abierto */
+}
+
+/* Media query para mostrar/ocultar elementos de escritorio/móvil */
+@media (max-width: 991px) { /* Breakpoint de Bootstrap para md/lg */
+    .ml-main-header .header-main-nav,
+    .ml-main-header .header-cta-button {
+        display: none; /* Ocultar navegación de escritorio y CTA */
+    }
+    .mobile-menu-container, .ml-mobile-nav { /* Mostrar elementos móviles */
+        display: flex; /* O block para .ml-mobile-nav, ajustado por JS */
+    }
+     .ml-mobile-nav { display: block; /* Asegurar que JS lo pueda manipular */}
+}
+
+
+/* --------------------------------------------------------------
+   Estilos para Secciones de la Página de Inicio (Continuación)
+-------------------------------------------------------------- */
+/* (El CSS de las secciones de la página de inicio ya está definido arriba) */
+
+
+/* --------------------------------------------------------------
+   Utilidades y Componentes Adicionales
+-------------------------------------------------------------- */
+
+/* Sticky header (ya incluido en .ml-main-header.is-scrolled) */
+
+/* Scroll to top button styling */
+.ml-scroll-to-top {
+    position: fixed;
+    bottom: 25px;
+    right: 25px;
+    background-color: var(--ml-color-primary);
+    color: white;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 48px;
+    font-size: 1.6rem;
+    box-shadow: 0 3px 8px rgba(0,0,0,0.15);
+    cursor: pointer;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(15px) scale(0.9);
+    transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease, background-color 0.2s ease;
+    z-index: 999;
+}
+.ml-scroll-to-top.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0) scale(1);
+}
+.ml-scroll-to-top:hover {
+    background-color: color-mix(in srgb, var(--ml-color-primary) 80%, black);
+    transform: scale(1.05); /* Slight pop on hover */
+}
+.ml-scroll-to-top .material-icons {
+    vertical-align: middle;
+    line-height: inherit; /* Ensure icon is centered */
+}
+
+/* Fallback para color-mix si el navegador no lo soporta */
+@supports not (color: color-mix(in srgb, white 50%, black)) {
+  .btn-primary:hover, .btn-primary:focus {
+    background-color: #5265b8; /* Pre-calculado más oscuro para #667eea */
+    border-color: #5265b8;
+  }
+  .btn-secondary:hover, .btn-secondary:focus {
+    background-color: #cc5656; /* Pre-calculado más oscuro para #ff6b6b */
+    border-color: #cc5656;
+  }
+   .ml-main-header .header-cta-button .btn.ml-contact-btn:hover {
+     background-color: #2c7a4b; /* Pre-calculado más oscuro para #38A169 */
+     border-color: #2c7a4b;
+   }
+   .ml-scroll-to-top:hover {
+    background-color: #5265b8;
+  }
+  .homepage-section .section-subtitle {
+    color: #555;
+  }
+   .products-section .subcategory-link {
+     color: #444;
+   }
+   .brands-section .brand-name {
+     color: #555;
+   }
+   .ecology-section .ecology-description {
+     color: #3a5031;
+   }
+}
+
+/* Fin de theme.css */

--- a/themes/mundolimpiotheme/assets/js/theme.js
+++ b/themes/mundolimpiotheme/assets/js/theme.js
@@ -1,0 +1,445 @@
+/**
+ * Mundo Limpio Theme - Main JavaScript (theme.js)
+ */
+'use strict';
+
+(function($) {
+    const MundoLimpioTheme = {
+        config: {
+            selectors: {
+                mobileMenuToggle: '.js-ml-menu-toggle',
+                mobileNav: '.js-ml-mobile-nav',
+                stickyHeader: 'header.ml-main-header',
+                scrollToTopButton: '.ml-scroll-to-top',
+                animatedElements: '.ml-animate-on-scroll',
+                lazyLoadImages: 'img.lazyload',
+                rippleEffectButtons: '.btn.ml-ripple-effect',
+                brandsSlider: '.brands-section .brands-slider',
+                brandsSliderTrack: '.brands-section .brands-track',
+                contactForms: 'form.js-contact-form'
+            },
+            stickyHeaderOffset: 50, // Changed from 100 to 50 as per React example
+            scrollToTopOffset: 400,
+            animationOffset: '100px',
+            lazyLoadRootMargin: '0px 0px 200px 0px',
+            throttleDelay: 100,
+            debounceDelay: 250,
+            brandsSlider: {
+                pauseOnHover: true
+            },
+            contactForm: {
+                clearFormAfterSuccess: true
+            }
+        },
+
+        init: function() {
+            this.initPrestashopDependencies();
+            this.initSmoothScroll();
+            this.initScrollAnimations();
+            this.initLazyLoading();
+            this.initMobileMenu();
+            this.initStickyHeader();
+            this.initScrollToTop();
+            this.initRippleEffects();
+            this.initBrandsSlider();
+            this.initContactForms();
+
+            $(window).on('scroll', this.utils.throttle(this.onScroll.bind(this), this.config.throttleDelay));
+            $(window).on('resize', this.utils.debounce(this.onResize.bind(this), this.config.debounceDelay));
+
+            this.onScroll();
+            this.onResize();
+            // console.log('Mundo Limpio Theme JS Initialized');
+        },
+
+        initPrestashopDependencies: function() {
+            window.prestashop = window.prestashop || {};
+            prestashop.modules = prestashop.modules || {};
+            prestashop.modules.mlthemebuilder = prestashop.modules.mlthemebuilder || {};
+            prestashop.modules.mlthemebuilder.translations = prestashop.modules.mlthemebuilder.translations || {
+                sending: 'Enviando...',
+                messageSent: '¡Mensaje enviado!',
+                errorSendingMessage: 'Error al enviar. Intente de nuevo.',
+                fillRequiredFields: 'Por favor, complete los campos requeridos.'
+            };
+            if (typeof prestashop.modules.mlthemebuilder.ajaxUrl !== 'undefined') {
+                this.config.contactForm.ajaxUrl = prestashop.modules.mlthemebuilder.ajaxUrl;
+            } else {
+                 let baseUrl = (prestashop.urls && prestashop.urls.base_url) ? prestashop.urls.base_url : window.location.origin + '/';
+                 if (!baseUrl.endsWith('/')) baseUrl += '/';
+                 this.config.contactForm.ajaxUrl = baseUrl + 'index.php?fc=module&module=mlthemebuilder&controller=ajax';
+                 // console.warn('MundoLimpioTheme: AJAX URL for contact form not found or misconfigured. Using fallback: ' + this.config.contactForm.ajaxUrl);
+            }
+        },
+
+        onScroll: function() {
+            this.handleStickyHeader(); // This will handle adding/removing 'is-scrolled'
+            this.handleScrollToTopButton();
+            this.triggerAnimationsOnScroll();
+            if (!('IntersectionObserver' in window)) {
+                this.checkLazyLoadFallback();
+            }
+        },
+
+        onResize: function() {
+            if (window.innerWidth > 991) {
+                const $toggle = $(this.config.selectors.mobileMenuToggle);
+                const $nav = $(this.config.selectors.mobileNav);
+                if ($nav.hasClass('open')) {
+                    $toggle.removeClass('open');
+                    $nav.removeClass('open');
+                    $('body').removeClass('mobile-menu-open');
+                }
+            }
+        },
+
+        initSmoothScroll: function() {
+            $('a[href^="#"]').not('[href="#"]').not('[href="#!"]').not('[data-toggle="tab"]').not('[data-toggle="collapse"]').on('click', function(e) {
+                const targetSelector = $(this).attr('href');
+                try {
+                    const $target = $(targetSelector);
+                    if ($target.length) {
+                        e.preventDefault();
+                        let offsetTop = $target.offset().top;
+                        const $stickyHeader = $(MundoLimpioTheme.config.selectors.stickyHeader);
+                        // Use the SCROLLED height if header is sticky, otherwise 0 or initial height if always visible
+                        if ($stickyHeader.length && $stickyHeader.hasClass('is-scrolled')) {
+                             offsetTop -= MundoLimpioTheme.config.stickyHeaderOffsetScrolled || 70; // Use defined scrolled height
+                        } else if ($stickyHeader.length && !$stickyHeader.hasClass('is-scrolled') && $stickyHeader.css('position') === 'fixed' && $stickyHeader.css('background-color') === 'transparent') {
+                            // If header is fixed but transparent (initial state), still account for its height
+                             offsetTop -= MundoLimpioTheme.config.stickyHeaderOffsetInitial || 80; // Use defined initial height
+                        }
+
+                        offsetTop -= 20;
+
+                        $('html, body').animate({ scrollTop: offsetTop }, 800, 'swing');
+                    }
+                } catch (error) {
+                    // console.warn('SmoothScroll: Invalid target selector:', targetSelector);
+                }
+            });
+        },
+
+        initScrollAnimations: function() {
+            this.$animatedElements = $(this.config.selectors.animatedElements);
+            if (!this.$animatedElements.length) return;
+
+            if ('IntersectionObserver' in window) {
+                const observer = new IntersectionObserver((entries, obs) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            const $el = $(entry.target);
+                            const animationType = $el.data('animation') || 'fadeInUp';
+                            const animationDelay = parseInt($el.data('delay')) || 0;
+
+                            setTimeout(() => {
+                                $el.addClass('animate-' + animationType).addClass('is-visible');
+                            }, animationDelay);
+
+                            obs.unobserve(entry.target);
+                        }
+                    });
+                }, {
+                    rootMargin: `0px 0px -${this.config.animationOffset} 0px`,
+                    threshold: 0.01
+                });
+                this.$animatedElements.each((i, el) => observer.observe(el));
+            } else {
+                this.triggerAnimationsOnScroll();
+            }
+        },
+        triggerAnimationsOnScroll: function() {
+             if ('IntersectionObserver' in window || !this.$animatedElements || !this.$animatedElements.length) return;
+            this.$animatedElements.each((i, el) => {
+                const $el = $(el);
+                if (this.utils.isElementInView($el[0], this.config.animationOffset) && !$el.hasClass('is-visible')) {
+                    const animationType = $el.data('animation') || 'fadeInUp';
+                    const animationDelay = parseInt($el.data('delay')) || 0;
+                    setTimeout(() => {
+                        $el.addClass('animate-' + animationType).addClass('is-visible');
+                    }, animationDelay);
+                }
+            });
+        },
+
+        initLazyLoading: function() {
+            this.$lazyImages = $(this.config.selectors.lazyLoadImages);
+            if (!this.$lazyImages.length) return;
+
+            if ('IntersectionObserver' in window) {
+                const observer = new IntersectionObserver((entries, obs) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            const img = entry.target;
+                            this.loadLazyImage(img);
+                            obs.unobserve(img);
+                        }
+                    });
+                }, { rootMargin: this.config.lazyLoadRootMargin });
+                this.$lazyImages.each((i, img) => observer.observe(img));
+            } else {
+                this.checkLazyLoadFallback();
+            }
+        },
+        loadLazyImage: function(img) {
+            const $img = $(img);
+            if ($img.data('src')) $img.attr('src', $img.data('src'));
+            if ($img.data('srcset')) $img.attr('srcset', $img.data('srcset'));
+            $img.removeClass('lazyload').addClass('lazyloaded').removeAttr('data-src data-srcset');
+        },
+        checkLazyLoadFallback: function() {
+            if ('IntersectionObserver' in window || !this.$lazyImages || !this.$lazyImages.length) return;
+            this.$lazyImages.each((i, img) => {
+                if ($(img).hasClass('lazyload') && this.utils.isElementInView(img, this.config.lazyLoadRootMargin)) {
+                    this.loadLazyImage(img);
+                }
+            });
+            this.$lazyImages = $(this.config.selectors.lazyLoadImages);
+        },
+
+        initMobileMenu: function() {
+            const $toggle = $(this.config.selectors.mobileMenuToggle);
+            const $menu = $(this.config.selectors.mobileNav);
+
+            if ($toggle.length && $menu.length) {
+                $toggle.on('click', function(e) {
+                    e.preventDefault();
+                    $menu.toggleClass('open');
+                    $(this).toggleClass('open');
+                    $('body').toggleClass('mobile-menu-open');
+                });
+
+                // Close menu if clicking on a link inside it (useful for one-page sites or anchor links)
+                $menu.find('a').on('click', function() {
+                    if ($menu.hasClass('open')) {
+                        $toggle.removeClass('open');
+                        $menu.removeClass('open');
+                        $('body').removeClass('mobile-menu-open');
+                    }
+                });
+            }
+        },
+
+        initStickyHeader: function() {
+            this.$stickyHeader = $(this.config.selectors.stickyHeader);
+            if (!this.$stickyHeader.length) return;
+            // Use the specific offset from config, not data-attribute from header element itself
+            this.stickyOffset = this.config.stickyHeaderOffset;
+            this.config.stickyHeaderOffsetScrolled = parseInt(this.$stickyHeader.css('--ml-header-height-scrolled')) || 70; // Get from CSS var
+            this.config.stickyHeaderOffsetInitial = parseInt(this.$stickyHeader.css('--ml-header-height')) || 80; // Get from CSS var
+
+            this.handleStickyHeader(); // Initial check
+        },
+        handleStickyHeader: function() { // This is called on scroll
+            if (!this.$stickyHeader || !this.$stickyHeader.length) return;
+            if ($(window).scrollTop() > this.stickyOffset) {
+                this.$stickyHeader.addClass('is-scrolled');
+            } else {
+                this.$stickyHeader.removeClass('is-scrolled');
+            }
+        },
+
+        initScrollToTop: function() {
+            this.$scrollToTopButton = $(this.config.selectors.scrollToTopButton);
+            if (!this.$scrollToTopButton.length) {
+                if ($('#ml-scroll-to-top-placeholder').length && !this.$scrollToTopButton.length) {
+                    $('body').append('<a href="#" class="ml-scroll-to-top" aria-label="Scroll to top"><i class="material-icons">keyboard_arrow_up</i></a>');
+                    this.$scrollToTopButton = $(this.config.selectors.scrollToTopButton);
+                } else {
+                    return;
+                }
+            }
+            this.$scrollToTopButton.on('click', (e) => {
+                e.preventDefault();
+                $('html, body').animate({ scrollTop: 0 }, 500);
+            });
+            this.handleScrollToTopButton();
+        },
+        handleScrollToTopButton: function() {
+            if (!this.$scrollToTopButton || !this.$scrollToTopButton.length) return;
+            if ($(window).scrollTop() > this.config.scrollToTopOffset) {
+                this.$scrollToTopButton.addClass('visible');
+            } else {
+                this.$scrollToTopButton.removeClass('visible');
+            }
+        },
+
+        initRippleEffects: function() {
+            $(this.config.selectors.rippleEffectButtons).on('click', function(e) {
+                const $button = $(this);
+                $button.find(".ripple-effect-span").remove();
+                const $ripple = $('<span class="ripple-effect-span"></span>');
+                const diameter = Math.max($button.outerWidth(), $button.outerHeight());
+                const radius = diameter / 2;
+                $ripple.css({
+                    width: diameter, height: diameter,
+                    left: e.pageX - $button.offset().left - radius,
+                    top: e.pageY - $button.offset().top - radius
+                }).appendTo($button);
+                setTimeout(() => $ripple.remove(), 700);
+            });
+        },
+
+        initBrandsSlider: function() {
+            const $sliderContainers = $(this.config.selectors.brandsSlider);
+            if (!$sliderContainers.length) return;
+
+            $sliderContainers.each(function() {
+                const $thisSlider = $(this);
+                const $track = $thisSlider.find(MundoLimpioTheme.config.selectors.brandsSliderTrack);
+                if (!$track.length) return;
+
+                const $items = $track.children('.brand-item');
+                if ($items.length <= 3) {
+                    $track.css('justify-content', 'center');
+                    return;
+                }
+
+                const sliderWidth = $thisSlider.width();
+                let trackWidth = 0;
+                $items.each(function() { trackWidth += $(this).outerWidth(true); });
+
+                if (trackWidth > sliderWidth) {
+                    $items.clone().appendTo($track);
+                    $track.css('width', trackWidth * 2);
+
+                    const duration = $thisSlider.data('duration') || "30s";
+                    $track.css({
+                        'animation-duration': duration,
+                        'animation-name': 'ml-scroll-brands'
+                    });
+                    // $track.addClass('css-animated'); // This class might not be needed if animation-name is set directly
+
+                    if (MundoLimpioTheme.config.brandsSlider.pauseOnHover) {
+                        $thisSlider.on('mouseenter', () => $track.css('animation-play-state', 'paused'));
+                        $thisSlider.on('mouseleave', () => $track.css('animation-play-state', 'running'));
+                    }
+                } else {
+                    $track.css('justify-content', 'center');
+                }
+            });
+        },
+
+        initContactForms: function() {
+            const self = this;
+            $(this.config.selectors.contactForms).each(function() {
+                const $form = $(this);
+                $form.on('submit', function(e) {
+                    e.preventDefault();
+                    const $submitButton = $form.find('button[type="submit"]');
+                    let $responseDiv = $form.find('.contact-form-response');
+                    if (!$responseDiv.length) {
+                        $responseDiv = $('<div class="contact-form-response" style="display:none; margin-top:15px;"></div>').insertAfter($submitButton);
+                    }
+
+                    let isValid = true;
+                    $form.find('[required]').each(function(){
+                        if(!$(this).val().trim()){ isValid = false; $(this).addClass('form-error'); }
+                        else { $(this).removeClass('form-error'); }
+                    });
+
+                    if (!isValid) {
+                        $responseDiv.html(`<p class="error-message">${prestashop.modules.mlthemebuilder.translations.fillRequiredFields}</p>`).show();
+                        return;
+                    }
+
+                    const formData = new FormData(this);
+
+                    const originalButtonText = $submitButton.html();
+                    $submitButton.html(prestashop.modules.mlthemebuilder.translations.sending).prop('disabled', true);
+                    $responseDiv.hide().removeClass('success-message error-message').empty();
+
+                    let ajaxUrl = $form.attr('action');
+                    let isNativeContactForm = ajaxUrl.includes('controller=contact'); // Check if it's PS native contact form
+
+                    if (!isNativeContactForm && (!ajaxUrl || ajaxUrl === '#')) {
+                        ajaxUrl = self.config.contactForm.ajaxUrl;
+                        if (!formData.has('action')) formData.append('action', 'submitContactForm'); // For our custom AJAX handler
+                        if (!formData.has('ajax')) formData.append('ajax', '1');
+                    }
+
+                    $.ajax({
+                        url: ajaxUrl,
+                        type: 'POST',
+                        data: formData,
+                        processData: false,
+                        contentType: false,
+                        dataType: isNativeContactForm ? 'html' : 'json', // Expect HTML from PS ContactController, JSON from ours
+                        success: function(response) {
+                            if (isNativeContactForm) {
+                                // Handle HTML response from PrestaShop's ContactController
+                                // Look for success/error messages within the HTML
+                                let $responseHtml = $('<div>').html(response);
+                                if ($responseHtml.find('.alert-success, .alert.alert-success').length > 0) {
+                                    $responseDiv.html(`<p class="success-message">${prestashop.modules.mlthemebuilder.translations.messageSent}</p>`).addClass('success-message').show();
+                                    if (self.config.contactForm.clearFormAfterSuccess) $form[0].reset();
+                                } else {
+                                     let errorMsg = $responseHtml.find('.alert-danger ul li, .alert.alert-danger ul li').first().text() || prestashop.modules.mlthemebuilder.translations.errorSendingMessage;
+                                     $responseDiv.html(`<p class="error-message">${errorMsg}</p>`).addClass('error-message').show();
+                                }
+                            } else {
+                                // Handle JSON response from our custom AJAX handler
+                                if (response.success || (response.sent && !response.error)) {
+                                    $responseDiv.html(`<p class="success-message">${response.message || prestashop.modules.mlthemebuilder.translations.messageSent}</p>`).addClass('success-message').show();
+                                    if (self.config.contactForm.clearFormAfterSuccess) $form[0].reset();
+                                } else {
+                                    let errors = response.errors || (response.message ? [response.message] : [prestashop.modules.mlthemebuilder.translations.errorSendingMessage]);
+                                    $responseDiv.html(`<p class="error-message">${errors.join('<br>')}</p>`).addClass('error-message').show();
+                                }
+                            }
+                        },
+                        error: function() {
+                            $responseDiv.html(`<p class="error-message">${prestashop.modules.mlthemebuilder.translations.errorSendingMessage}</p>`).addClass('error-message').show();
+                        },
+                        complete: function() {
+                            $submitButton.html(originalButtonText).prop('disabled', false);
+                            setTimeout(() => $responseDiv.fadeOut(() => $responseDiv.empty().removeClass('success-message error-message')), 7000);
+                        }
+                    });
+                });
+            });
+        },
+
+        utils: {
+            isElementInView: function(el, offsetOption = '0px') {
+                const rect = el.getBoundingClientRect();
+                const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
+                let offsetValue = 0;
+                if (typeof offsetOption === 'string') {
+                    if (offsetOption.includes('%')) {
+                        offsetValue = (parseFloat(offsetOption) / 100) * viewHeight;
+                    } else {
+                        offsetValue = parseInt(offsetOption) || 0;
+                    }
+                }
+                return rect.top < (viewHeight - offsetValue) && rect.bottom > offsetValue;
+            },
+            throttle: function(func, limit) {
+                let inThrottle;
+                return function() {
+                    const args = arguments;
+                    const context = this;
+                    if (!inThrottle) {
+                        func.apply(context, args);
+                        inThrottle = true;
+                        setTimeout(() => inThrottle = false, limit);
+                    }
+                };
+            },
+            debounce: function(func, delay) {
+                let timeout;
+                return function() {
+                    const context = this;
+                    const args = arguments;
+                    clearTimeout(timeout);
+                    timeout = setTimeout(() => func.apply(context, args), delay);
+                };
+            }
+        }
+    };
+
+    $(document).ready(function() {
+        MundoLimpioTheme.init();
+    });
+
+})(jQuery);

--- a/themes/mundolimpiotheme/config/theme.yml
+++ b/themes/mundolimpiotheme/config/theme.yml
@@ -1,0 +1,123 @@
+name: mundolimpiotheme
+display_name: Mundo Limpio Theme
+version: 1.0.0
+author:
+  name: "Byron Briones"
+  email: "contacto@bbrion.es"
+  url: "https://bbrion.es"
+
+meta:
+  compatibility:
+    from: 1.7.6
+    to: ~ # Compatible with future versions as well
+
+  available_layouts: # Inherited from classic, can be overridden if needed
+    layout-full-width:
+      name: Full Width
+      description: "No side columns, ideal for distraction-free pages such as product pages."
+    layout-both-columns:
+      name: Three Columns
+      description: "One large central column and 2 side columns."
+    layout-left-column:
+      name: Two Columns, small left column
+      description: "Two columns with a small left column"
+    layout-right-column:
+      name: Two Columns, small right column
+      description: "Two columns with a small right column"
+
+assets: # Define assets - CSS and JS files
+  css:
+    all: # For all pages
+      - id: mundolimpio-style # Unique ID for your main theme CSS
+        path: assets/css/theme.css
+        media: all
+        priority: 200 # Higher priority to override parent theme styles
+      - id: mundolimpio-custom # For user's custom CSS overrides
+        path: assets/css/custom.css
+        media: all
+        priority: 210
+  js:
+    all: # For all pages
+      - id: mundolimpio-scripts # Unique ID for your main theme JS
+        path: assets/js/theme.js
+        priority: 200
+        position: bottom # Load at the end of the body
+      # Posible inclusión de la fuente Montserrat desde Google Fonts
+      # - id: montserrat-font
+      #   path: https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap
+      #   server: remote
+      #   media: all
+      #   priority: 10 # Cargar antes que nuestro theme.css
+
+parent: classic # Specifies that this is a child theme of 'classic'
+
+layouts:
+  # By default, layouts are inherited from the 'classic' parent theme.
+  # You can override specific page layouts here if needed.
+  # For example, to make the homepage full width by default:
+  index: layout-full-width
+  # category: layout-left-column
+  # product: layout-full-width
+  # cms: layout-left-column
+
+# global_settings:
+  # This section can be used to define settings manageable via the Theme Customizer in BO.
+  # Example:
+  #   colors:
+  #     primary:
+  #       label: "Primary Color"
+  #       type: "color"
+  #       value: "#007bff" # Default value
+  #       description: "Main color for buttons and links."
+  #   font:
+  #     primary_font:
+  #       label: "Primary Font"
+  #       type: "text" # Could be select if limited options
+  #       value: "'Roboto', sans-serif"
+  # image_formats:
+  #   # Define custom image formats or override existing ones
+  #   product_miniature:
+  #     width: 300
+  #     height: 300
+  #     scope: [products]
+
+# dependencies:
+  # List modules that this theme depends on.
+  # modules:
+  #   - ps_imageslider
+  #   - ps_customtext
+# hooks:
+  # Register custom hooks for your theme if needed
+  # displayCustomHomeBlock:
+  #   name: displayCustomHomeBlock
+  #   title: Custom Home Block
+  #   description: Hook for a custom block on the homepage.
+  #   page: index
+  #   position: 1
+# Demo pages (for theme preview in BO)
+# demo_pages:
+#   product_url: '#' # URL to a sample product page for preview
+#   category_url: '#' # URL to a sample category page
+#   cms_url: '#' # URL to a sample CMS page
+#   index_url: '#' # URL to the homepage
+
+# Options for the theme configurator (if you build one)
+# configurator:
+#   logo_url: assets/img/logo-configurator.png
+#   favicon_url: assets/img/favicon-configurator.png
+
+# Defines if the theme uses the new product page experimental feature
+# use_ પણ_product_page_v2: true
+
+# Defines if the theme uses the new checkout page experimental feature
+# use_ પણ_checkout_v2: true
+
+# Specifies the default font for the theme
+# default_font: "Open Sans"
+
+# Specifies assets to exclude from the parent theme
+# parent_assets_to_exclude:
+#   css:
+#     - id: classic-style # Example: exclude classic's main CSS
+#   js:
+#     - id: classic-scripts # Example: exclude classic's main JS

--- a/themes/mundolimpiotheme/preview.png
+++ b/themes/mundolimpiotheme/preview.png
@@ -1,0 +1,6 @@
+Este es un archivo de imagen PNG placeholder. Debería ser reemplazado con una captura de pantalla real del tema de 1000x750px aproximadamente.
+Por ahora, este contenido de texto sirve como marcador de posición para el archivo binario.
+Dimensions: 1000x750 (ideal)
+Format: PNG
+Content: A representative screenshot of the theme's homepage or key design elements.
+Fallback text if image cannot be rendered: "Mundo Limpio Theme Preview"

--- a/themes/mundolimpiotheme/templates/_partials/header.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/header.tpl
@@ -1,0 +1,102 @@
+{**
+ * Mundo Limpio Theme - Custom Header
+ * Based on React design and PrestaShop Classic structure.
+ *}
+
+{block name='header_banner'}
+  {hook h='displayBanner'} {* Mantenemos el hook de banner por si se usa *}
+{/block}
+
+{* Nuevo header principal que envuelve la navegación y el logo según el diseño React *}
+<header id="header" class="ml-main-header {if Configuration::get('MLTHEME_HEADER_STICKY', null, null, $shop.id)}js-sticky-header{/if}"> {* La clase js-sticky-header la usará nuestro theme.js *}
+  <div class="container">
+    <div class="header-inner-wrapper"> {* Equivalente al flex items-center justify-between *}
+
+      <div class="header-logo-container">
+        <a href="{$urls.base_url}">
+          {if !empty($shop.logo_details.desktop.url)} {* PS 1.7.8+ usa logo_details *}
+            <img class="logo img-responsive"
+                 src="{$shop.logo_details.desktop.url}"
+                 alt="{$shop.name|escape:'htmlall':'UTF-8'}"
+                 {if !empty($shop.logo_details.desktop.width)}width="{$shop.logo_details.desktop.width|escape:'htmlall':'UTF-8'}"{/if}
+                 {if !empty($shop.logo_details.desktop.height)}height="{$shop.logo_details.desktop.height|escape:'htmlall':'UTF-8'}"{/if}>
+          {elseif !empty($shop.logo.url)} {* Fallback para PS < 1.7.8 o si logo_details no está completo *}
+            <img class="logo img-responsive"
+                 src="{$shop.logo.url}"
+                 alt="{$shop.name|escape:'htmlall':'UTF-8'}"
+                 {if !empty($shop.logo.width)}width="{$shop.logo.width|escape:'htmlall':'UTF-8'}"{/if}
+                 {if !empty($shop.logo.height)}height="{$shop.logo.height|escape:'htmlall':'UTF-8'}"{/if}>
+          {elseif !empty($shop.logo)} {* Fallback si $shop.logo es solo la URL directa *}
+             <img class="logo img-responsive"
+                 src="{$shop.logo|escape:'htmlall':'UTF-8'}"
+                 alt="{$shop.name|escape:'htmlall':'UTF-8'}">
+          {else}
+            <span class="text-logo">{$shop.name|escape:'htmlall':'UTF-8'}</span> {* Fallback a texto si no hay logo *}
+          {/if}
+        </a>
+      </div>
+
+      <nav class="header-main-nav hidden-md-down"> {* hidden-md-down para ocultar en móvil *}
+        {hook h='displayTop'} {* Aquí se enganchará ps_mainmenu u otro módulo de menú *}
+      </nav>
+
+      <div class="header-cta-button hidden-md-down">
+        <a href="{$urls.pages.contact|escape:'htmlall':'UTF-8'}" class="btn btn-primary ml-contact-btn"> {* Clase específica para estilizar si es necesario *}
+          {l s='Contactar Ahora' d='Shop.Theme.Actions'}
+        </a>
+      </div>
+
+      {* --- Menú Móvil --- *}
+      <div class="mobile-menu-container hidden-lg-up"> {* hidden-lg-up para mostrar solo en móvil/tablet *}
+        <button class="btn-icon js-ml-menu-toggle" id="menu-icon" aria-label="{l s='Toggle navigation' d='Shop.Theme.Actions'}">
+          <i class="material-icons">menu</i> {* Icono de hamburguesa *}
+        </button>
+
+        {* Carrito e info de usuario para móvil (podemos usar los hooks de Classic aquí si es necesario) *}
+        <div class="mobile-header-right-icons">
+            {hook h='displayMobileTopSiteMap'} {* Para el carrito e info de usuario en móvil como en Classic *}
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  {* Panel del menú móvil que se mostrará/ocultará con JS *}
+  <div class="ml-mobile-nav hidden-lg-up" id="js-ml-mobile-nav">
+    <div class="container">
+        {* El contenido del menú móvil. Podría ser el mismo hook 'displayTop' o uno específico si el módulo de menú lo soporta.
+           También se puede construir un menú simple aquí si se prefiere. *}
+        {hook h='displayTop'}
+
+        <div class="mobile-nav-cta">
+             <a href="{$urls.pages.contact|escape:'htmlall':'UTF-8'}" class="btn btn-primary btn-block">
+                {l s='Contactar Ahora' d='Shop.Theme.Actions'}
+            </a>
+        </div>
+
+        {* Opcional: Enlaces adicionales para móvil como los de header_nav de Classic *}
+        <div class="mobile-nav-bottom-links">
+            {hook h='displayNavMobile'} {* Un nuevo hook si queremos contenido diferente al displayNav1/2 *}
+            {* O replicar displayNav1 y displayNav2 si es necesario *}
+            {* {hook h='displayNav1'} *}
+            {* {hook h='displayNav2'} *}
+        </div>
+    </div>
+  </div>
+
+  {* Mantener el displayNavFullWidth por si algún módulo lo usa extensivamente, aunque el menú principal ya está en displayTop *}
+  {* El hook displayNavFullWidth se suele usar para menús que ocupan todo el ancho debajo del header principal,
+     como a veces se ve en el tema Classic. Lo mantenemos aquí por compatibilidad,
+     aunque nuestro menú principal ahora está en displayTop dentro del header. *}
+    {block name='header_nav_full_width_hook'}
+      <div class="nav-full-width-container">
+          {hook h='displayNavFullWidth'}
+      </div>
+    {/block}
+</header>
+
+{* Los bloques header_nav y header_top originales de Classic se han omitido intencionalmente
+   en esta nueva estructura para lograr el diseño deseado.
+   Los hooks importantes como displayBanner, displayTop y displayNavFullWidth se han conservado.
+   Si se necesita displayNav1 o displayNav2, se pueden añadir en una nueva ubicación o dentro de displayNavMobile.
+*}

--- a/themes/mundolimpiotheme/templates/_partials/homepage/banner.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/banner.tpl
@@ -1,0 +1,26 @@
+{**
+ * Banner CTA Section for Mundo Limpio Theme Homepage
+ * Content is semi-static for now.
+ *}
+<section class="homepage-section banner-cta-section" id="cta-banner">
+    <div class="container banner-container">
+        <div class="banner-content"> {* Default: text-left, image-right. Add class 'image-left' for reverse *}
+            <div class="banner-text">
+                <h2 class="banner-title">{l s='Únete a la Revolución Limpia' d='Shop.Theme.Mundolimpio'}</h2>
+                <p class="banner-description">{l s='Suscríbete a nuestro boletín y obtén un 10% de descuento en tu primera compra, además de consejos para un estilo de vida más sostenible.' d='Shop.Theme.Mundolimpio'}</p>
+                {* Ejemplo de un formulario de suscripción simple o un botón a una página de registro *}
+                {* <form action="#" method="post" class="banner-form">
+                    <input type="email" name="email" placeholder="{l s='Tu correo electrónico' d='Shop.Forms.Labels'}" required>
+                    <button type="submit" class="btn btn-light banner-btn">{l s='Suscribirme' d='Shop.Theme.Actions'}</button>
+                </form> *}
+                 <a href="#" class="btn btn-light banner-btn ml-ripple-effect">{* TODO: Link to newsletter subscription or special offer page *}
+                    {l s='Descubre Más y Ahorra' d='Shop.Theme.Actions'}
+                </a>
+            </div>
+            <div class="banner-image">
+                 {* Placeholder - Reemplazar con una imagen real o configurable *}
+                <img src="{$urls.theme_assets}img/placeholders/banner-cta-600x400.png" alt="{l s='Promoción Mundo Limpio' d='Shop.Theme.Mundolimpio'}" class="banner-img lazyload">
+            </div>
+        </div>
+    </div>
+</section>

--- a/themes/mundolimpiotheme/templates/_partials/homepage/brands.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/brands.tpl
@@ -1,0 +1,38 @@
+{**
+ * Brands Slider Section for Mundo Limpio Theme Homepage
+ * Content is semi-static for now.
+ *}
+<section class="homepage-section brands-section" id="brands">
+    <div class="container">
+        <div class="section-header">
+            <h2 class="section-title">{l s='Marcas que Inspiran Confianza' d='Shop.Theme.Mundolimpio'}</h2>
+            {* <p class="section-subtitle">{l s='Colaboramos con marcas comprometidas con la sostenibilidad y la calidad.' d='Shop.Theme.Mundolimpio'}</p> *}
+        </div>
+        <div class="brands-slider" data-duration="30s"> {* data-duration para control JS si es necesario *}
+            <div class="brands-track">
+                {* Ejemplo de Logos - Reemplazar con logos reales o un sistema dinámico *}
+                {assign var=brand_logos value=[
+                    ['name' => 'Marca Eco 1', 'logo' => '{$urls.theme_assets}img/placeholders/brand-logo-150x60.png', 'url' => '#'],
+                    ['name' => 'Sello Orgánico', 'logo' => '{$urls.theme_assets}img/placeholders/brand-logo-150x60.png', 'url' => '#'],
+                    ['name' => 'Certificado Verde', 'logo' => '{$urls.theme_assets}img/placeholders/brand-logo-150x60.png', 'url' => '#'],
+                    ['name' => 'Amigo del Planeta', 'logo' => '{$urls.theme_assets}img/placeholders/brand-logo-150x60.png', 'url' => '#'],
+                    ['name' => 'Naturalmente Tuyo', 'logo' => '{$urls.theme_assets}img/placeholders/brand-logo-150x60.png', 'url' => '#'],
+                    ['name' => 'Comercio Justo Garantizado', 'logo' => '{$urls.theme_assets}img/placeholders/brand-logo-150x60.png', 'url' => '#']
+                ]}
+
+                {foreach from=$brand_logos item=brand}
+                    <div class="brand-item">
+                        {if $brand.url && $brand.url != '#'}
+                            <a href="{$brand.url nofilter}" target="_blank" rel="noopener noreferrer" title="{$brand.name|escape:'htmlall':'UTF-8'}">
+                        {/if}
+                        <img src="{$brand.logo nofilter}" alt="{$brand.name|escape:'htmlall':'UTF-8'}" class="brand-logo lazyload">
+                        {if $brand.url && $brand.url != '#'}
+                            </a>
+                        {/if}
+                    </div>
+                {/foreach}
+                {* Se duplicarán por JS para el efecto de scroll infinito si es necesario, o por CSS *}
+            </div>
+        </div>
+    </div>
+</section>

--- a/themes/mundolimpiotheme/templates/_partials/homepage/contact.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/contact.tpl
@@ -1,0 +1,90 @@
+{**
+ * Contact Section for Mundo Limpio Theme Homepage
+ * Content is semi-static for now.
+ *}
+<section class="homepage-section contact-section" id="contact">
+    <div class="container">
+        <div class="section-header">
+            <h2 class="section-title">{l s='¿Hablamos? Estamos Aquí para Ayudarte' d='Shop.Theme.Mundolimpio'}</h2>
+            <p class="section-subtitle">{l s='Si tienes preguntas, sugerencias o simplemente quieres saludar, no dudes en contactarnos.' d='Shop.Theme.Mundolimpio'}</p>
+        </div>
+        <div class="contact-content">
+            <div class="contact-info">
+                <div class="contact-item ml-animate-on-scroll anim-fadeInLeft">
+                    <i class="material-icons">location_on</i>
+                    <div>
+                        <h4>{l s='Nuestra Tienda (Pick-up Point)' d='Shop.Theme.Mundolimpio'}</h4>
+                        <p>{* TODO: Replace with actual address or use {$shop.addresses.address1} etc. if configured *}
+                            Calle Falsa 123, Ciudad Verde<br>
+                            Provincia Ejemplo, Argentina
+                        </p>
+                    </div>
+                </div>
+                <div class="contact-item ml-animate-on-scroll anim-fadeInLeft" data-delay="100">
+                    <i class="material-icons">phone</i>
+                    <div>
+                        <h4>{l s='Llámanos' d='Shop.Theme.Mundolimpio'}</h4>
+                        <p><a href="tel:+540111234567">{* TODO: Replace with actual phone or {$shop.phone} *} (+54) 011-1234-5678</a></p>
+                    </div>
+                </div>
+                <div class="contact-item ml-animate-on-scroll anim-fadeInLeft" data-delay="200">
+                    <i class="material-icons">email</i>
+                    <div>
+                        <h4>{l s='Escríbenos' d='Shop.Theme.Mundolimpio'}</h4>
+                        <p><a href="mailto:{$shop.email|escape:'htmlall':'UTF-8'}">{$shop.email|escape:'htmlall':'UTF-8'}</a></p>
+                    </div>
+                </div>
+                <div class="contact-item ml-animate-on-scroll anim-fadeInLeft" data-delay="300">
+                    <i class="material-icons">schedule</i>
+                    <div>
+                        <h4>{l s='Horarios de Atención' d='Shop.Theme.Mundolimpio'}</h4>
+                        <p>{* TODO: Replace with actual hours *}
+                            Lunes a Viernes: 9:00 - 18:00 hs<br>
+                            Sábados: 10:00 - 14:00 hs
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="contact-form-wrapper ml-animate-on-scroll anim-fadeInRight">
+                <h3 class="form-title">{l s='Envíanos un Mensaje Directo' d='Shop.Theme.Mundolimpio'}</h3>
+                <form id="homepageContactForm" class="contact-form-inner js-contact-form" action="{$urls.pages.contact nofilter}" method="post">
+                    {* Este es un formulario HTML básico. Para funcionalidad completa (envío de email, validación),
+                       se necesitaría un módulo de contacto o lógica AJAX que envíe a un controlador.
+                       Por ahora, es visual. El JS en theme.js intentará manejarlo vía AJAX si está configurado.
+                    *}
+                    <input type="hidden" name="from_page" value="homepage_contact_section">
+                     <input type="hidden" name="id_contact" value="{$contact_form_id_contact|default:0}"> {* ID del contacto de la tienda para el controlador de contacto de PS *}
+                    <input type="hidden" name="token" value="{$static_token}">
+
+
+                    <div class="form-group">
+                        <label for="hp-contact-name" class="sr-only">{l s='Tu Nombre' d='Shop.Forms.Labels'}</label>
+                        <input type="text" id="hp-contact-name" name="from" class="form-control" placeholder="{l s='Tu Nombre' d='Shop.Forms.Labels'}" required>
+                    </div>
+                    <div class="form-group">
+                         <label for="hp-contact-email" class="sr-only">{l s='Tu Correo Electrónico' d='Shop.Forms.Labels'}</label>
+                        <input type="email" id="hp-contact-email" name="email" class="form-control" placeholder="{l s='Tu Correo Electrónico' d='Shop.Forms.Labels'}" required>
+                    </div>
+                     <div class="form-group">
+                        <label for="hp-contact-subject" class="sr-only">{l s='Asunto' d='Shop.Forms.Labels'}</label>
+                        <input type="text" id="hp-contact-subject" name="subject" class="form-control" placeholder="{l s='Asunto' d='Shop.Forms.Labels'}" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="hp-contact-message" class="sr-only">{l s='Tu Mensaje' d='Shop.Forms.Labels'}</label>
+                        <textarea id="hp-contact-message" name="message" class="form-control" placeholder="{l s='Tu Mensaje' d='Shop.Forms.Labels'}" rows="5" required></textarea>
+                    </div>
+                    <button type="submit" name="submitMessage" class="btn btn-primary btn-block ml-ripple-effect">
+                        {l s='Enviar Mensaje' d='Shop.Theme.Actions'}
+                    </button>
+                    <div class="contact-form-response" style="display:none; margin-top:15px;"></div>
+                </form>
+            </div>
+        </div>
+
+        {* Placeholder para un mapa si se desea. Se podría usar un iframe de Google Maps.
+        <div class="contact-map" style="margin-top: 40px;">
+            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d....YOUR_MAP_EMBED_CODE" width="100%" height="350" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+        </div>
+        *}
+    </div>
+</section>

--- a/themes/mundolimpiotheme/templates/_partials/homepage/ecology.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/ecology.tpl
@@ -1,0 +1,39 @@
+{**
+ * Ecology Section for Mundo Limpio Theme Homepage
+ * Content is semi-static for now.
+ *}
+<section class="homepage-section ecology-section" id="ecology">
+    <div class="container">
+        <div class="ecology-content"> {* Default: text-left, image-right. Add class 'image-left' for reverse *}
+            <div class="ecology-text">
+                <h2 class="ecology-title">{l s='Nuestro Pacto con el Planeta' d='Shop.Theme.Mundolimpio'}</h2>
+                <p class="ecology-description">{l s='En Mundo Limpio, cada producto es un paso hacia un futuro más verde. Creemos en la transparencia, la responsabilidad y el poder de las elecciones conscientes.' d='Shop.Theme.Mundolimpio'}</p>
+                <div class="ecology-items">
+                    {assign var=ecology_points value=[
+                        ['icon' => 'forest', 'text' => {l s='Ingredientes de Origen Sostenible' d='Shop.Theme.Mundolimpio'}],
+                        ['icon' => 'recycling', 'text' => {l s='Empaques Eco-Amigables y Minimizados' d='Shop.Theme.Mundolimpio'}],
+                        ['icon' => 'local_florist', 'text' => {l s='Libre de Crueldad Animal (Cruelty-Free)' d='Shop.Theme.Mundolimpio'}],
+                        ['icon' => 'handshake', 'text' => {l s='Apoyo a Comunidades y Comercio Justo' d='Shop.Theme.Mundolimpio'}]
+                    ]}
+                    {foreach from=$ecology_points item=point name=ecologyLoop}
+                        {* Assign the calculated delay to a variable first to ensure it's treated as a number before being outputted *}
+                        {assign var="animation_delay" value=$smarty.foreach.ecologyLoop.iteration * 100}
+                        <div class="ecology-item ml-animate-on-scroll anim-fadeInLeft" data-delay="{$animation_delay|escape:'htmlall':'UTF-8'}">
+                            <i class="material-icons">{$point.icon|escape:'htmlall':'UTF-8'}</i>
+                            <span>{$point.text|escape:'htmlall':'UTF-8'}</span>
+                        </div>
+                    {/foreach}
+                </div>
+                 <div class="ecology-button" style="margin-top: 25px;">
+                    <a href="#" class="btn btn-primary ml-ripple-effect">{* TODO: Link to a page about sustainability efforts *}
+                        {l s='Conoce Más Sobre Nuestro Impacto' d='Shop.Theme.Actions'}
+                    </a>
+                </div>
+            </div>
+            <div class="ecology-image ml-animate-on-scroll anim-fadeInRight">
+                {* Placeholder - Reemplazar con una imagen real o configurable *}
+                <img src="{$urls.theme_assets}img/placeholders/ecology-image-600x500.png" alt="{l s='Compromiso ecológico de Mundo Limpio' d='Shop.Theme.Mundolimpio'}" class="ecology-img lazyload">
+            </div>
+        </div>
+    </div>
+</section>

--- a/themes/mundolimpiotheme/templates/_partials/homepage/hero.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/hero.tpl
@@ -1,0 +1,25 @@
+{**
+ * Hero Section for Mundo Limpio Theme Homepage
+ * Content is semi-static for now.
+ *}
+<section class="homepage-section hero-section" id="hero">
+    <div class="container hero-container">
+        <div class="hero-content">
+            <div class="hero-text">
+                <h1 class="hero-title">{l s='Mundo Limpio: Frescura y Cuidado Natural' d='Shop.Theme.Mundolimpio'}</h1>
+                <p class="hero-subtitle">{l s='Descubre nuestra gama de productos ecológicos para un hogar saludable y un planeta feliz.' d='Shop.Theme.Mundolimpio'}</p>
+                <div class="hero-buttons">
+                    <a href="{$urls.pages.category nofilter}{* TODO: Add category ID or link to all products *}" class="btn btn-primary hero-btn ml-ripple-effect">
+                        {l s='Explorar Productos' d='Shop.Theme.Actions'}
+                    </a>
+                    {* <a href="#" class="btn btn-outline-light hero-btn-secondary">{l s='Más Sobre Nosotros' d='Shop.Theme.Actions'}</a> *}
+                </div>
+            </div>
+            <div class="hero-image">
+                {* Placeholder - Reemplazar con una imagen real o configurable *}
+                <img src="{$urls.theme_assets}img/placeholders/hero-placeholder-800x600.png" alt="{l s='Productos ecológicos de Mundo Limpio' d='Shop.Theme.Mundolimpio'}" class="hero-img lazyload">
+                {* Ejemplo con imagen del tema: <img src="{$urls.theme_assets}img/hero-main.jpg" alt="..." > *}
+            </div>
+        </div>
+    </div>
+</section>

--- a/themes/mundolimpiotheme/templates/_partials/homepage/products.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/products.tpl
@@ -1,0 +1,102 @@
+{**
+ * Products Section for Mundo Limpio Theme Homepage
+ * Content is semi-static for now. Could display featured products or categories.
+ *}
+<section class="homepage-section products-section" id="products">
+    <div class="container">
+        <div class="section-header">
+            <h2 class="section-title">{l s='Productos Estrella para un Mundo Limpio' d='Shop.Theme.Mundolimpio'}</h2>
+            <p class="section-subtitle">{l s='Descubre nuestras soluciones más populares y efectivas para un hogar sostenible.' d='Shop.Theme.Mundolimpio'}</p>
+        </div>
+
+        {* Aquí podríamos usar un hook para un módulo como "Productos Destacados" (ps_featuredproducts)
+           o podríamos codificar una lista de categorías o productos específicos.
+           Por ahora, mostraremos un placeholder o un ejemplo de cómo se verían las categorías.
+        *}
+
+        {* Ejemplo: Mostrar algunas categorías principales *}
+        {* Smarty 3 syntax for associative arrays within assign is `foo=[bar=>'baz']` or more complexly, build step-by-step.
+           For simplicity with complex structures directly in template, consider JSON and then `json_decode` if really needed,
+           or better, prepare in PHP if this were a module.
+           Here, we'll define them more simply for direct use.
+        *}
+        <div class="categories-grid">
+            {$category_example_1_name = {l s='Limpieza del Hogar' d='Shop.Theme.Mundolimpio'}}
+            {$category_example_1_image = "`$urls.theme_assets`img/placeholders/category-hogar-400x300.png"}
+            {$category_example_1_link = "#link-categoria-hogar"}
+            {$category_example_1_subcategories = [
+                ['name' => {l s='Cocina' d='Shop.Theme.Mundolimpio'}, 'link' => '#'],
+                ['name' => {l s='Baño' d='Shop.Theme.Mundolimpio'}, 'link' => '#']
+            ]}
+
+            {$category_example_2_name = {l s='Cuidado Personal' d='Shop.Theme.Mundolimpio'}}
+            {$category_example_2_image = "`$urls.theme_assets`img/placeholders/category-personal-400x300.png"}
+            {$category_example_2_link = "#link-categoria-personal"}
+            {$category_example_2_subcategories = [
+                ['name' => {l s='Jabones' d='Shop.Theme.Mundolimpio'}, 'link' => '#'],
+                ['name' => {l s='Champús' d='Shop.Theme.Mundolimpio'}, 'link' => '#']
+            ]}
+
+            {$category_example_3_name = {l s='Bebés y Niños' d='Shop.Theme.Mundolimpio'}}
+            {$category_example_3_image = "`$urls.theme_assets`img/placeholders/category-bebes-400x300.png"}
+            {$category_example_3_link = "#link-categoria-bebes"}
+            {$category_example_3_subcategories = []}
+
+            {* Now create an array of these structures *}
+            {assign var="category_examples" value=[
+                [
+                    'name' => $category_example_1_name,
+                    'image' => $category_example_1_image,
+                    'link' => $category_example_1_link,
+                    'subcategories' => $category_example_1_subcategories
+                ],
+                [
+                    'name' => $category_example_2_name,
+                    'image' => $category_example_2_image,
+                    'link' => $category_example_2_link,
+                    'subcategories' => $category_example_2_subcategories
+                ],
+                [
+                    'name' => $category_example_3_name,
+                    'image' => $category_example_3_image,
+                    'link' => $category_example_3_link,
+                    'subcategories' => $category_example_3_subcategories
+                ]
+            ]}
+
+            {foreach from=$category_examples item=category_item}
+                <div class="category-card ml-animate-on-scroll anim-scaleIn">
+                    <div class="category-image">
+                        <a href="{$category_item.link|escape:'htmlall':'UTF-8'}">
+                            <img src="{$category_item.image|escape:'htmlall':'UTF-8'}" alt="{$category_item.name|escape:'htmlall':'UTF-8'}" class="category-img lazyload">
+                        </a>
+                    </div>
+                    <div class="category-content">
+                        <h3 class="category-title"><a href="{$category_item.link|escape:'htmlall':'UTF-8'}">{$category_item.name|escape:'htmlall':'UTF-8'}</a></h3>
+                        {if $category_item.subcategories}
+                            <div class="subcategories">
+                                {foreach from=$category_item.subcategories item=subcategory}
+                                    <a href="{$subcategory.link|escape:'htmlall':'UTF-8'}" class="subcategory-link">{$subcategory.name|escape:'htmlall':'UTF-8'}</a>
+                                {/foreach}
+                            </div>
+                        {/if}
+                        <a href="{$category_item.link|escape:'htmlall':'UTF-8'}" class="btn btn-outline category-btn">{l s='Ver Productos' d='Shop.Theme.Actions'}</a>
+                    </div>
+                </div>
+            {/foreach}
+        </div>
+
+        {* Alternativamente, si quisieras usar el hook de productos destacados:
+           {hook h='displayHomeTabContent'}
+           O directamente:
+           {widget name="ps_featuredproducts" hook="displayHome"}
+        *}
+
+        <div class="text-center" style="margin-top: 40px;">
+             <a href="{$urls.pages.category nofilter}{* TODO: Link to main products/categories page *}" class="btn btn-primary btn-lg">
+                {l s='Ver Todos los Productos' d='Shop.Theme.Actions'}
+            </a>
+        </div>
+
+    </div>
+</section>

--- a/themes/mundolimpiotheme/templates/_partials/homepage/services.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/homepage/services.tpl
@@ -1,0 +1,48 @@
+{**
+ * Services Section for Mundo Limpio Theme Homepage
+ * Content is semi-static for now.
+ *}
+<section class="homepage-section services-section" id="services">
+    <div class="container">
+        <div class="section-header">
+            <h2 class="section-title">{l s='Nuestros Compromisos y Servicios' d='Shop.Theme.Mundolimpio'}</h2>
+            <p class="section-subtitle">{l s='Calidad, sostenibilidad y atención personalizada para ti y el medio ambiente.' d='Shop.Theme.Mundolimpio'}</p>
+        </div>
+        <div class="services-grid">
+            {* Item 1 *}
+            <div class="service-card ml-animate-on-scroll anim-fadeInUp">
+                <div class="service-icon">
+                    <i class="material-icons">eco</i> {* O usa una clase FontAwesome: <i class="fas fa-leaf"></i> *}
+                </div>
+                <h3 class="service-title">{l s='Productos 100% Ecológicos' d='Shop.Theme.Mundolimpio'}</h3>
+                <p class="service-description">{l s='Ingredientes naturales y biodegradables, amigables con tu hogar y el planeta.' d='Shop.Theme.Mundolimpio'}</p>
+            </div>
+            {* Item 2 *}
+            <div class="service-card ml-animate-on-scroll anim-fadeInUp" data-delay="100">
+                <div class="service-icon">
+                    <i class="material-icons">local_shipping</i> {* <i class="fas fa-truck"></i> *}
+                </div>
+                <h3 class="service-title">{l s='Envíos Conscientes' d='Shop.Theme.Mundolimpio'}</h3>
+                <p class="service-description">{l s='Empaques reciclados y opciones de envío de bajo impacto para reducir nuestra huella.' d='Shop.Theme.Mundolimpio'}</p>
+            </div>
+            {* Item 3 *}
+            <div class="service-card ml-animate-on-scroll anim-fadeInUp" data-delay="200">
+                <div class="service-icon">
+                    <i class="material-icons">support_agent</i> {* <i class="fas fa-headset"></i> *}
+                </div>
+                <h3 class="service-title">{l s='Asesoramiento Personalizado' d='Shop.Theme.Mundolimpio'}</h3>
+                <p class="service-description">{l s='Te ayudamos a elegir los productos ideales para tus necesidades y un estilo de vida más verde.' d='Shop.Theme.Mundolimpio'}</p>
+            </div>
+            {* Puedes añadir más items si lo deseas *}
+            {* Item 4 (ejemplo adicional)
+            <div class="service-card ml-animate-on-scroll anim-fadeInUp" data-delay="300">
+                <div class="service-icon">
+                    <i class="material-icons">recycling</i>
+                </div>
+                <h3 class="service-title">{l s='Fomentamos el Reciclaje' d='Shop.Theme.Mundolimpio'}</h3>
+                <p class="service-description">{l s='Promovemos la reutilización y el reciclaje de envases para cerrar el ciclo.' d='Shop.Theme.Mundolimpio'}</p>
+            </div>
+            *}
+        </div>
+    </div>
+</section>

--- a/themes/mundolimpiotheme/templates/index.tpl
+++ b/themes/mundolimpiotheme/templates/index.tpl
@@ -1,0 +1,50 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+{extends file='page.tpl'}
+
+    {block name='page_content_container'}
+      <!-- Tema Mundo Limpio Hijo Activo -->
+      <section id="content" class="page-home">
+        {block name='page_content_top'}{/block}
+
+        {block name='page_content'}
+          {* Este es el bloque principal donde se mostrarán las secciones personalizadas.
+             El hook_home original se puede mantener si algunos módulos estándar aún lo usan,
+             o se puede reemplazar completamente con nuestra estructura de secciones.
+             Por ahora, lo comentaremos para reemplazarlo con nuestra propia lógica de secciones.
+          *}
+          {* {$HOOK_HOME nofilter} *}
+
+          {include file="./_partials/homepage/hero.tpl"}
+          {include file="./_partials/homepage/services.tpl"}
+          {include file="./_partials/homepage/products.tpl"}
+          {include file="./_partials/homepage/banner.tpl"}
+          {include file="./_partials/homepage/brands.tpl"}
+          {include file="./_partials/homepage/ecology.tpl"}
+          {include file="./_partials/homepage/contact.tpl"}
+
+        {/block}
+      </section>
+    {/block}


### PR DESCRIPTION
Addresses a TypeError "Cannot access offset of type string on string" when accessing shop logo properties.

This occurs if `\$shop.logo` is a direct string URL instead of an array/object with `desktop.url`, `desktop.width`, etc., or if it's not fully populated.

The fix checks for the existence and structure of `\$shop.logo_details.desktop.url` (used in PS 1.7.8+) first. If not found, it falls back to checking `\$shop.logo.url` (for older PS versions or simpler logo configurations). As a final fallback if `\$shop.logo` is just a string URL, it uses that directly for the src. If no logo is found at all, it displays the shop name as text.

This makes the logo rendering more resilient to variations in how PrestaShop provides the logo variable depending on version and configuration.