### PR TITLE
fix: More robust logo handling in header.tpl

### DIFF
--- a/themes/mundolimpiotheme/templates/_partials/header.tpl
+++ b/themes/mundolimpiotheme/templates/_partials/header.tpl
@@ -14,25 +14,38 @@
 
       <div class="header-logo-container">
         <a href="{$urls.base_url}">
-          {if !empty($shop.logo_details.desktop.url)} {* PS 1.7.8+ usa logo_details *}
-            <img class="logo img-responsive"
-                 src="{$shop.logo_details.desktop.url}"
-                 alt="{$shop.name|escape:'htmlall':'UTF-8'}"
-                 {if !empty($shop.logo_details.desktop.width)}width="{$shop.logo_details.desktop.width|escape:'htmlall':'UTF-8'}"{/if}
-                 {if !empty($shop.logo_details.desktop.height)}height="{$shop.logo_details.desktop.height|escape:'htmlall':'UTF-8'}"{/if}>
-          {elseif !empty($shop.logo.url)} {* Fallback para PS < 1.7.8 o si logo_details no está completo *}
-            <img class="logo img-responsive"
-                 src="{$shop.logo.url}"
-                 alt="{$shop.name|escape:'htmlall':'UTF-8'}"
-                 {if !empty($shop.logo.width)}width="{$shop.logo.width|escape:'htmlall':'UTF-8'}"{/if}
-                 {if !empty($shop.logo.height)}height="{$shop.logo.height|escape:'htmlall':'UTF-8'}"{/if}>
-          {elseif !empty($shop.logo)} {* Fallback si $shop.logo es solo la URL directa *}
-             <img class="logo img-responsive"
-                 src="{$shop.logo|escape:'htmlall':'UTF-8'}"
-                 alt="{$shop.name|escape:'htmlall':'UTF-8'}">
-          {else}
-            <span class="text-logo">{$shop.name|escape:'htmlall':'UTF-8'}</span> {* Fallback a texto si no hay logo *}
-          {/if}
+            {assign var=logo_url value=''}
+            {assign var=logo_width value=''}
+            {assign var=logo_height value=''}
+
+            {if isset($shop.logo_details.desktop.url) && $shop.logo_details.desktop.url != ''}
+                {assign var=logo_url value=$shop.logo_details.desktop.url}
+                {if isset($shop.logo_details.desktop.width)}{assign var=logo_width value=$shop.logo_details.desktop.width}{/if}
+                {if isset($shop.logo_details.desktop.height)}{assign var=logo_height value=$shop.logo_details.desktop.height}{/if}
+            {elseif isset($shop.logo.url) && $shop.logo.url != ''} {* PS < 1.7.8 o fallback *}
+                {assign var=logo_url value=$shop.logo.url}
+                {if isset($shop.logo.width)}{assign var=logo_width value=$shop.logo.width}{/if}
+                {if isset($shop.logo.height)}{assign var=logo_height value=$shop.logo.height}{/if}
+            {elseif is_string($shop.logo) && $shop.logo != ''} {* Si $shop.logo es solo una URL string *}
+                {assign var=logo_url value=$shop.logo}
+            {/if}
+
+            {if $logo_url != ''}
+                <img class="logo img-responsive"
+                     src="{$logo_url|escape:'htmlall':'UTF-8'}"
+                     alt="{$shop.name|escape:'htmlall':'UTF-8'}"
+                     {if $logo_width != ''}width="{$logo_width|escape:'htmlall':'UTF-8'}"{/if}
+                     {if $logo_height != ''}height="{$logo_height|escape:'htmlall':'UTF-8'}"{/if}>
+            {else}
+                {* Fallback si no hay logo configurado en la tienda *}
+                {if isset($shop.logo_details) && isset($shop.logo_details.default_logo_url) && $shop.logo_details.default_logo_url != ''}
+                     <img class="logo img-responsive"
+                         src="{$shop.logo_details.default_logo_url|escape:'htmlall':'UTF-8'}"
+                         alt="{$shop.name|escape:'htmlall':'UTF-8'}">
+                {else}
+                    <span class="text-logo">{$shop.name|escape:'htmlall':'UTF-8'}</span>
+                {/if}
+            {/if}
         </a>
       </div>
 


### PR DESCRIPTION
Implements a more defensive approach to rendering the shop logo in `themes/mundolimpiotheme/templates/_partials/header.tpl` to prevent TypeError when `\$shop.logo` or `\$shop.logo_details` do not have the expected array structure.

Changes:
- Initializes `$logo_url`, `$logo_width`, `$logo_height` Smarty variables.
- Checks `\$shop.logo_details.desktop.url` (for PS 1.7.8+).
- Falls back to `\$shop.logo.url` (for older PS or simpler configs).
- Falls back to using `\$shop.logo` directly if it's a string URL.
- If a valid logo URL is found, renders the `<img>` tag.
- If no logo URL is found after all checks, it attempts to use `\$shop.logo_details.default_logo_url` if available (new PrestaShop versions provide this for the default PrestaShop logo when no custom logo is uploaded).
- As a final fallback, displays the shop name as text if no image source can be determined.

This should prevent the "Cannot access offset of type string on string" error by ensuring that array/object access is only attempted on variables that are confirmed to be of the correct type and structure.