### PR TITLE
feat: Integrar Material Icons

### DIFF
--- a/templates/_partials/header.tpl
+++ b/templates/_partials/header.tpl
@@ -7,6 +7,8 @@
   {hook h='displayBanner'}
 {/block}
 
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
 <header id="header" class="ml-main-header {if Configuration::get('MLTHEME_HEADER_STICKY', null, null, $shop.id)}js-sticky-header{/if}">
   <div class="container">
     <div class="header-inner-wrapper">


### PR DESCRIPTION
Se agrega la hoja de estilos de Google Fonts para Material Icons en el `header.tpl` para permitir el uso de los íconos en todo el tema.