### PR TITLE
fix: Hacer que la sección del héroe ocupe todo el ancho

### DIFF
--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -30,12 +30,12 @@
         {block name='page_content_top'}{/block}
 
         {block name='page_content'}
-
           {include file="./_partials/homepage/hero.tpl"}
-
-          <div class="container">
-            {include file="./_partials/homepage/services.tpl"}
-          </div>
+        {/block}
+      </section>
+      <div class="container">
+        {block name='page_content_container_lower'}
+          {include file="./_partials/homepage/services.tpl"}
 
           <div class="container">
             {include file="./_partials/homepage/products.tpl"}


### PR DESCRIPTION
- Se mueve la inclusión de `hero.tpl` fuera del div contenedor principal en `index.tpl` para que ocupe todo el ancho de la pantalla.