### PR TITLE
fix: Aislar los estilos del encabezado de Classic

### DIFF
--- a/assets/css/header-classic.css
+++ b/assets/css/header-classic.css
@@ -1,0 +1,156 @@
+#header {
+    position: relative;
+    z-index: 999;
+    color: #7a7a7a;
+    background: #fff;
+    -webkit-box-shadow: 0 2px 5px 0 rgba(0,0,0,.11);
+    box-shadow: 0 2px 5px 0 rgba(0,0,0,.11)
+}
+
+#header .logo {
+    max-width: 250px;
+    height: auto;
+}
+
+#header a:hover {
+    color: #24b9d7;
+    text-decoration: none
+}
+
+#header .menu,#header .menu>ul>li {
+    display: inline-block
+}
+
+#header .header-nav {
+    max-height: 50px;
+    border-bottom: #f6f6f6 2px solid
+}
+
+#header .header-nav #menu-icon {
+    margin: 0 1rem;
+    vertical-align: middle;
+    cursor: pointer
+}
+
+#header .header-nav #menu-icon .material-icons {
+    line-height: 50px
+}
+
+#header .header-nav .right-nav {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    -webkit-box-pack: end;
+    -ms-flex-pack: end;
+    justify-content: flex-end
+}
+
+#header .header-nav .currency-selector {
+    margin-top: .9375rem;
+    margin-left: .9375rem;
+    white-space: nowrap
+}
+
+#header .header-nav .user-info {
+    margin-left: 2.5rem;
+    text-align: right
+}
+
+#header .header-nav .user-info .account {
+    margin-left: .625rem
+}
+
+#header .header-nav .language-selector,#header .header-nav .user-info {
+    margin-top: .9375rem;
+    white-space: nowrap
+}
+
+#header .header-nav .cart-preview.active {
+    background: #24b9d7
+}
+
+#header .header-nav .blockcart.active a:hover,#header .header-nav .cart-preview.active a,#header .header-nav .cart-preview.active i {
+    color: #fff
+}
+
+#header .header-nav .cart-preview .shopping-cart {
+    color: #7a7a7a;
+    vertical-align: middle
+}
+
+#header .header-nav .cart-preview .body {
+    display: none
+}
+
+#header .header-nav .blockcart {
+    height: 3rem;
+    padding: .75rem;
+    margin-left: .9375rem;
+    text-align: center;
+    white-space: nowrap;
+    background: #f6f6f6
+}
+
+#header .header-nav .blockcart a:hover {
+    color: #24b9d7
+}
+
+#header .header-nav .blockcart .header {
+    margin-top: .125rem
+}
+
+#header .header-nav #_desktop_contact_link {
+    display: inline-block
+}
+
+#header .header-nav .search-widget {
+    margin-top: .2rem
+}
+
+#header .header-nav .material-icons {
+    line-height: inherit
+}
+
+#header .header-nav .material-icons.expand-more {
+    margin-left: -.375rem
+}
+
+#header .header-top {
+    padding: 1.25rem 0
+}
+
+#header .header-top>.container {
+    position: relative
+}
+
+#header .header-top>.container>.row:first-of-type {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center
+}
+
+#header .header-top .menu {
+    padding-left: 15px
+}
+
+#header .header-top .position-static {
+    position: static
+}
+
+#header .header-top a[data-depth="0"] {
+    color: #7a7a7a;
+    text-transform: uppercase
+}
+
+#header .header-top .search-widget {
+    float: right
+}
+
+#header .top-menu-link {
+    margin-left: 1.25rem
+}

--- a/assets/css/src/main.css
+++ b/assets/css/src/main.css
@@ -1,5 +1,3 @@
-@import "../../../classic/assets/css/theme.css";
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,6 +1,4 @@
-@import "../../../classic/assets/css/theme.css";
-
-*, ::before, ::after{
+*, ::before, ::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;
@@ -54,7 +52,7 @@
   --tw-contain-style:  ;
 }
 
-::backdrop{
+::backdrop {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;
@@ -106,13 +104,9 @@
   --tw-contain-layout:  ;
   --tw-contain-paint:  ;
   --tw-contain-style:  ;
-}
-
-/*
+}/*
 ! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com
-*/
-
-/*
+*//*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
 */
@@ -429,7 +423,6 @@ menu {
 /*
 Reset default styling for dialogs.
 */
-
 dialog {
   padding: 0;
 }
@@ -470,7 +463,6 @@ button,
 /*
 Make sure disabled buttons don't get the pointer cursor.
 */
-
 :disabled {
   cursor: default;
 }
@@ -504,900 +496,899 @@ video {
 }
 
 /* Make elements with the HTML hidden attribute stay hidden by default */
-
 [hidden]:where(:not([hidden="until-found"])) {
   display: none;
 }
-.container{
+.container {
   width: 100%;
 }
-@media (min-width: 640px){
+@media (min-width: 640px) {
 
-  .container{
+  .container {
     max-width: 640px;
   }
 }
-@media (min-width: 768px){
+@media (min-width: 768px) {
 
-  .container{
+  .container {
     max-width: 768px;
   }
 }
-@media (min-width: 1024px){
+@media (min-width: 1024px) {
 
-  .container{
+  .container {
     max-width: 1024px;
   }
 }
-@media (min-width: 1280px){
+@media (min-width: 1280px) {
 
-  .container{
+  .container {
     max-width: 1280px;
   }
 }
-@media (min-width: 1536px){
+@media (min-width: 1536px) {
 
-  .container{
+  .container {
     max-width: 1536px;
   }
 }
-.absolute{
+.absolute {
   position: absolute;
 }
-.relative{
+.relative {
   position: relative;
 }
-.inset-0{
+.inset-0 {
   inset: 0px;
 }
-.bottom-20{
+.bottom-20 {
   bottom: 5rem;
 }
-.left-1\/3{
+.left-1\/3 {
   left: 33.333333%;
 }
-.left-10{
+.left-10 {
   left: 2.5rem;
 }
-.right-10{
+.right-10 {
   right: 2.5rem;
 }
-.top-1\/2{
+.top-1\/2 {
   top: 50%;
 }
-.top-20{
+.top-20 {
   top: 5rem;
 }
-.z-10{
+.z-10 {
   z-index: 10;
 }
-.mx-4{
+.mx-4 {
   margin-left: 1rem;
   margin-right: 1rem;
 }
-.mx-auto{
+.mx-auto {
   margin-left: auto;
   margin-right: auto;
 }
-.mb-10{
+.mb-10 {
   margin-bottom: 2.5rem;
 }
-.mb-12{
+.mb-12 {
   margin-bottom: 3rem;
 }
-.mb-16{
+.mb-16 {
   margin-bottom: 4rem;
 }
-.mb-2{
+.mb-2 {
   margin-bottom: 0.5rem;
 }
-.mb-20{
+.mb-20 {
   margin-bottom: 5rem;
 }
-.mb-3{
+.mb-3 {
   margin-bottom: 0.75rem;
 }
-.mb-4{
+.mb-4 {
   margin-bottom: 1rem;
 }
-.mb-6{
+.mb-6 {
   margin-bottom: 1.5rem;
 }
-.mb-8{
+.mb-8 {
   margin-bottom: 2rem;
 }
-.ml-2{
+.ml-2 {
   margin-left: 0.5rem;
 }
-.mr-3{
+.mr-3 {
   margin-right: 0.75rem;
 }
-.mt-1{
+.mt-1 {
   margin-top: 0.25rem;
 }
-.mt-2{
+.mt-2 {
   margin-top: 0.5rem;
 }
-.mt-20{
+.mt-20 {
   margin-top: 5rem;
 }
-.mt-8{
+.mt-8 {
   margin-top: 2rem;
 }
-.block{
+.block {
   display: block;
 }
-.inline-block{
+.inline-block {
   display: inline-block;
 }
-.flex{
+.flex {
   display: flex;
 }
-.inline-flex{
+.inline-flex {
   display: inline-flex;
 }
-.grid{
+.grid {
   display: grid;
 }
-.h-10{
+.h-10 {
   height: 2.5rem;
 }
-.h-12{
+.h-12 {
   height: 3rem;
 }
-.h-16{
+.h-16 {
   height: 4rem;
 }
-.h-2{
+.h-2 {
   height: 0.5rem;
 }
-.h-20{
+.h-20 {
   height: 5rem;
 }
-.h-32{
+.h-32 {
   height: 8rem;
 }
-.h-40{
+.h-40 {
   height: 10rem;
 }
-.h-48{
+.h-48 {
   height: 12rem;
 }
-.h-6{
+.h-6 {
   height: 1.5rem;
 }
-.h-60{
+.h-60 {
   height: 15rem;
 }
-.h-80{
+.h-80 {
   height: 20rem;
 }
-.h-full{
+.h-full {
   height: 100%;
 }
-.max-h-full{
+.max-h-full {
   max-height: 100%;
 }
-.min-h-screen{
+.min-h-screen {
   min-height: 100vh;
 }
-.w-10{
+.w-10 {
   width: 2.5rem;
 }
-.w-12{
+.w-12 {
   width: 3rem;
 }
-.w-2{
+.w-2 {
   width: 0.5rem;
 }
-.w-20{
+.w-20 {
   width: 5rem;
 }
-.w-32{
+.w-32 {
   width: 8rem;
 }
-.w-40{
+.w-40 {
   width: 10rem;
 }
-.w-48{
+.w-48 {
   width: 12rem;
 }
-.w-6{
+.w-6 {
   width: 1.5rem;
 }
-.w-60{
+.w-60 {
   width: 15rem;
 }
-.w-80{
+.w-80 {
   width: 20rem;
 }
-.w-auto{
+.w-auto {
   width: auto;
 }
-.w-full{
+.w-full {
   width: 100%;
 }
-.max-w-2xl{
+.max-w-2xl {
   max-width: 42rem;
 }
-.max-w-3xl{
+.max-w-3xl {
   max-width: 48rem;
 }
-.max-w-4xl{
+.max-w-4xl {
   max-width: 56rem;
 }
-.max-w-6xl{
+.max-w-6xl {
   max-width: 72rem;
 }
-.max-w-full{
+.max-w-full {
   max-width: 100%;
 }
-.max-w-lg{
+.max-w-lg {
   max-width: 32rem;
 }
-.flex-shrink-0{
+.flex-shrink-0 {
   flex-shrink: 0;
 }
-.rotate-45{
+.rotate-45 {
   --tw-rotate: 45deg;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
-.transform{
+.transform {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
-.cursor-pointer{
+.cursor-pointer {
   cursor: pointer;
 }
-.grid-cols-2{
+.grid-cols-2 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
-.flex-col{
+.flex-col {
   flex-direction: column;
 }
-.flex-wrap{
+.flex-wrap {
   flex-wrap: wrap;
 }
-.items-start{
+.items-start {
   align-items: flex-start;
 }
-.items-center{
+.items-center {
   align-items: center;
 }
-.justify-center{
+.justify-center {
   justify-content: center;
 }
-.justify-between{
+.justify-between {
   justify-content: space-between;
 }
-.gap-1{
+.gap-1 {
   gap: 0.25rem;
 }
-.gap-12{
+.gap-12 {
   gap: 3rem;
 }
-.gap-4{
+.gap-4 {
   gap: 1rem;
 }
-.gap-8{
+.gap-8 {
   gap: 2rem;
 }
-.space-x-2 > :not([hidden]) ~ :not([hidden]){
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(0.5rem * var(--tw-space-x-reverse));
   margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
 }
-.space-x-3 > :not([hidden]) ~ :not([hidden]){
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(0.75rem * var(--tw-space-x-reverse));
   margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
 }
-.space-x-4 > :not([hidden]) ~ :not([hidden]){
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(1rem * var(--tw-space-x-reverse));
   margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
-.space-x-8 > :not([hidden]) ~ :not([hidden]){
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(2rem * var(--tw-space-x-reverse));
   margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
 }
-.space-y-2 > :not([hidden]) ~ :not([hidden]){
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
 }
-.space-y-4 > :not([hidden]) ~ :not([hidden]){
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
 }
-.space-y-6 > :not([hidden]) ~ :not([hidden]){
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
 }
-.overflow-hidden{
+.overflow-hidden {
   overflow: hidden;
 }
-.rounded{
+.rounded {
   border-radius: 0.25rem;
 }
-.rounded-2xl{
+.rounded-2xl {
   border-radius: 1rem;
 }
-.rounded-3xl{
+.rounded-3xl {
   border-radius: 1.5rem;
 }
-.rounded-full{
+.rounded-full {
   border-radius: 9999px;
 }
-.rounded-lg{
+.rounded-lg {
   border-radius: 0.5rem;
 }
-.rounded-xl{
+.rounded-xl {
   border-radius: 0.75rem;
 }
-.border{
+.border {
   border-width: 1px;
 }
-.border-0{
+.border-0 {
   border-width: 0px;
 }
-.border-t{
+.border-t {
   border-top-width: 1px;
 }
-.border-gray-700{
+.border-gray-700 {
   --tw-border-opacity: 1;
   border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
 }
-.border-white{
+.border-white {
   --tw-border-opacity: 1;
   border-color: rgb(255 255 255 / var(--tw-border-opacity, 1));
 }
-.border-white\/20{
+.border-white\/20 {
   border-color: rgb(255 255 255 / 0.2);
 }
-.bg-blue-100{
+.bg-blue-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(219 234 254 / var(--tw-bg-opacity, 1));
 }
-.bg-blue-600{
+.bg-blue-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
 }
-.bg-corporate-blue{
+.bg-corporate-blue {
   --tw-bg-opacity: 1;
   background-color: rgb(0 100 182 / var(--tw-bg-opacity, 1));
 }
-.bg-corporate-blue\/10{
+.bg-corporate-blue\/10 {
   background-color: rgb(0 100 182 / 0.1);
 }
-.bg-corporate-blue\/5{
+.bg-corporate-blue\/5 {
   background-color: rgb(0 100 182 / 0.05);
 }
-.bg-corporate-green{
+.bg-corporate-green {
   --tw-bg-opacity: 1;
   background-color: rgb(76 175 80 / var(--tw-bg-opacity, 1));
 }
-.bg-corporate-green\/20{
+.bg-corporate-green\/20 {
   background-color: rgb(76 175 80 / 0.2);
 }
-.bg-corporate-green\/5{
+.bg-corporate-green\/5 {
   background-color: rgb(76 175 80 / 0.05);
 }
-.bg-gray-100{
+.bg-gray-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
 }
-.bg-gray-50{
+.bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
 }
-.bg-gray-600{
+.bg-gray-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(75 85 99 / var(--tw-bg-opacity, 1));
 }
-.bg-green-100{
+.bg-green-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(220 252 231 / var(--tw-bg-opacity, 1));
 }
-.bg-green-600{
+.bg-green-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
 }
-.bg-purple-100{
+.bg-purple-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(243 232 255 / var(--tw-bg-opacity, 1));
 }
-.bg-purple-600{
+.bg-purple-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(147 51 234 / var(--tw-bg-opacity, 1));
 }
-.bg-white{
+.bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
 }
-.bg-white\/10{
+.bg-white\/10 {
   background-color: rgb(255 255 255 / 0.1);
 }
-.bg-white\/5{
+.bg-white\/5 {
   background-color: rgb(255 255 255 / 0.05);
 }
-.bg-yellow-100{
+.bg-yellow-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 249 195 / var(--tw-bg-opacity, 1));
 }
-.bg-gradient-to-br{
+.bg-gradient-to-br {
   background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
 }
-.from-corporate-blue{
+.from-corporate-blue {
   --tw-gradient-from: #0064b6 var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(0 100 182 / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
-.from-corporate-blue\/5{
+.from-corporate-blue\/5 {
   --tw-gradient-from: rgb(0 100 182 / 0.05) var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(0 100 182 / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
-.from-gray-900{
+.from-gray-900 {
   --tw-gradient-from: #111827 var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(17 24 39 / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
-.via-blue-700{
+.via-blue-700 {
   --tw-gradient-to: rgb(29 78 216 / 0)  var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), #1d4ed8 var(--tw-gradient-via-position), var(--tw-gradient-to);
 }
-.via-gray-50{
+.via-gray-50 {
   --tw-gradient-to: rgb(249 250 251 / 0)  var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), #f9fafb var(--tw-gradient-via-position), var(--tw-gradient-to);
 }
-.via-gray-800{
+.via-gray-800 {
   --tw-gradient-to: rgb(31 41 55 / 0)  var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), #1f2937 var(--tw-gradient-via-position), var(--tw-gradient-to);
 }
-.to-blue-600{
+.to-blue-600 {
   --tw-gradient-to: #2563eb var(--tw-gradient-to-position);
 }
-.to-corporate-green\/5{
+.to-corporate-green\/5 {
   --tw-gradient-to: rgb(76 175 80 / 0.05) var(--tw-gradient-to-position);
 }
-.to-cyan-500{
+.to-cyan-500 {
   --tw-gradient-to: #06b6d4 var(--tw-gradient-to-position);
 }
-.to-slate-900{
+.to-slate-900 {
   --tw-gradient-to: #0f172a var(--tw-gradient-to-position);
 }
-.to-white{
+.to-white {
   --tw-gradient-to: #fff var(--tw-gradient-to-position);
 }
-.object-contain{
+.object-contain {
   -o-object-fit: contain;
      object-fit: contain;
 }
-.p-3{
+.p-3 {
   padding: 0.75rem;
 }
-.p-6{
+.p-6 {
   padding: 1.5rem;
 }
-.p-8{
+.p-8 {
   padding: 2rem;
 }
-.px-2{
+.px-2 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
-.px-4{
+.px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
 }
-.px-8{
+.px-8 {
   padding-left: 2rem;
   padding-right: 2rem;
 }
-.py-1{
+.py-1 {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
 }
-.py-16{
+.py-16 {
   padding-top: 4rem;
   padding-bottom: 4rem;
 }
-.py-2{
+.py-2 {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
-.py-20{
+.py-20 {
   padding-top: 5rem;
   padding-bottom: 5rem;
 }
-.py-24{
+.py-24 {
   padding-top: 6rem;
   padding-bottom: 6rem;
 }
-.py-3{
+.py-3 {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
 }
-.py-4{
+.py-4 {
   padding-top: 1rem;
   padding-bottom: 1rem;
 }
-.py-8{
+.py-8 {
   padding-top: 2rem;
   padding-bottom: 2rem;
 }
-.pb-6{
+.pb-6 {
   padding-bottom: 1.5rem;
 }
-.pb-8{
+.pb-8 {
   padding-bottom: 2rem;
 }
-.text-center{
+.text-center {
   text-align: center;
 }
-.font-montserrat{
+.font-montserrat {
   font-family: Montserrat, sans-serif;
 }
-.text-2xl{
+.text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
 }
-.text-3xl{
+.text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
 }
-.text-4xl{
+.text-4xl {
   font-size: 2.25rem;
   line-height: 2.5rem;
 }
-.text-5xl{
+.text-5xl {
   font-size: 3rem;
   line-height: 1;
 }
-.text-lg{
+.text-lg {
   font-size: 1.125rem;
   line-height: 1.75rem;
 }
-.text-sm{
+.text-sm {
   font-size: 0.875rem;
   line-height: 1.25rem;
 }
-.text-xl{
+.text-xl {
   font-size: 1.25rem;
   line-height: 1.75rem;
 }
-.text-xs{
+.text-xs {
   font-size: 0.75rem;
   line-height: 1rem;
 }
-.font-bold{
+.font-bold {
   font-weight: 700;
 }
-.font-medium{
+.font-medium {
   font-weight: 500;
 }
-.font-semibold{
+.font-semibold {
   font-weight: 600;
 }
-.leading-relaxed{
+.leading-relaxed {
   line-height: 1.625;
 }
-.leading-tight{
+.leading-tight {
   line-height: 1.25;
 }
-.text-blue-100{
+.text-blue-100 {
   --tw-text-opacity: 1;
   color: rgb(219 234 254 / var(--tw-text-opacity, 1));
 }
-.text-corporate-blue{
+.text-corporate-blue {
   --tw-text-opacity: 1;
   color: rgb(0 100 182 / var(--tw-text-opacity, 1));
 }
-.text-corporate-green{
+.text-corporate-green {
   --tw-text-opacity: 1;
   color: rgb(76 175 80 / var(--tw-text-opacity, 1));
 }
-.text-gray-300{
+.text-gray-300 {
   --tw-text-opacity: 1;
   color: rgb(209 213 219 / var(--tw-text-opacity, 1));
 }
-.text-gray-400{
+.text-gray-400 {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity, 1));
 }
-.text-gray-600{
+.text-gray-600 {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity, 1));
 }
-.text-gray-700{
+.text-gray-700 {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity, 1));
 }
-.text-purple-600{
+.text-purple-600 {
   --tw-text-opacity: 1;
   color: rgb(147 51 234 / var(--tw-text-opacity, 1));
 }
-.text-white{
+.text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
-.text-yellow-600{
+.text-yellow-600 {
   --tw-text-opacity: 1;
   color: rgb(202 138 4 / var(--tw-text-opacity, 1));
 }
-.opacity-0{
+.opacity-0 {
   opacity: 0;
 }
-.shadow-lg{
+.shadow-lg {
   --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
-.shadow-xl{
+.shadow-xl {
   --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
-.blur-2xl{
+.blur-2xl {
   --tw-blur: blur(40px);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
-.blur-3xl{
+.blur-3xl {
   --tw-blur: blur(64px);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
-.blur-xl{
+.blur-xl {
   --tw-blur: blur(24px);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
-.grayscale{
+.grayscale {
   --tw-grayscale: grayscale(100%);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
-.filter{
+.filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
-.backdrop-blur-sm{
+.backdrop-blur-sm {
   --tw-backdrop-blur: blur(4px);
   -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
-.transition-all{
+.transition-all {
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
-.transition-colors{
+.transition-colors {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
-.transition-opacity{
+.transition-opacity {
   transition-property: opacity;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
-.transition-shadow{
+.transition-shadow {
   transition-property: box-shadow;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
-.transition-transform{
+.transition-transform {
   transition-property: transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
-.duration-300{
+.duration-300 {
   transition-duration: 300ms;
 }
-.duration-500{
+.duration-500 {
   transition-duration: 500ms;
 }
 
 /* Custom base styles can be added here */
-body{
+body {
   font-family: Open Sans, sans-serif; /* Sets the default font to Open Sans, defined in tailwind.config.js */
 }
-.hover\:-translate-y-2:hover{
+.hover\:-translate-y-2:hover {
   --tw-translate-y: -0.5rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
-.hover\:bg-green-600:hover{
+.hover\:bg-green-600:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
 }
-.hover\:bg-white:hover{
+.hover\:bg-white:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
 }
-.hover\:text-corporate-blue:hover{
+.hover\:text-corporate-blue:hover {
   --tw-text-opacity: 1;
   color: rgb(0 100 182 / var(--tw-text-opacity, 1));
 }
-.hover\:text-corporate-green:hover{
+.hover\:text-corporate-green:hover {
   --tw-text-opacity: 1;
   color: rgb(76 175 80 / var(--tw-text-opacity, 1));
 }
-.hover\:text-white:hover{
+.hover\:text-white:hover {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
-.hover\:shadow-2xl:hover{
+.hover\:shadow-2xl:hover {
   --tw-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
   --tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
-.hover\:shadow-lg:hover{
+.hover\:shadow-lg:hover {
   --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
-.hover\:shadow-xl:hover{
+.hover\:shadow-xl:hover {
   --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
-.group:hover .group-hover\:translate-x-1{
+.group:hover .group-hover\:translate-x-1 {
   --tw-translate-x: 0.25rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
-.group:hover .group-hover\:scale-110{
+.group:hover .group-hover\:scale-110 {
   --tw-scale-x: 1.1;
   --tw-scale-y: 1.1;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
-.group:hover .group-hover\:text-corporate-green{
+.group:hover .group-hover\:text-corporate-green {
   --tw-text-opacity: 1;
   color: rgb(76 175 80 / var(--tw-text-opacity, 1));
 }
-.group:hover .group-hover\:text-white{
+.group:hover .group-hover\:text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
-.group:hover .group-hover\:opacity-100{
+.group:hover .group-hover\:opacity-100 {
   opacity: 1;
 }
-.group:hover .group-hover\:grayscale-0{
+.group:hover .group-hover\:grayscale-0 {
   --tw-grayscale: grayscale(0);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
-@media (min-width: 640px){
+@media (min-width: 640px) {
 
-  .sm\:flex-row{
+  .sm\:flex-row {
     flex-direction: row;
   }
 }
-@media (min-width: 768px){
+@media (min-width: 768px) {
 
-  .md\:mx-6{
+  .md\:mx-6 {
     margin-left: 1.5rem;
     margin-right: 1.5rem;
   }
 
-  .md\:mb-12{
+  .md\:mb-12 {
     margin-bottom: 3rem;
   }
 
-  .md\:mb-16{
+  .md\:mb-16 {
     margin-bottom: 4rem;
   }
 
-  .md\:mb-20{
+  .md\:mb-20 {
     margin-bottom: 5rem;
   }
 
-  .md\:mb-4{
+  .md\:mb-4 {
     margin-bottom: 1rem;
   }
 
-  .md\:mb-6{
+  .md\:mb-6 {
     margin-bottom: 1.5rem;
   }
 
-  .md\:mb-8{
+  .md\:mb-8 {
     margin-bottom: 2rem;
   }
 
-  .md\:grid-cols-2{
+  .md\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .md\:grid-cols-3{
+  .md\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .md\:grid-cols-4{
+  .md\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
-  .md\:gap-6{
+  .md\:gap-6 {
     gap: 1.5rem;
   }
 
-  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]){
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-x-reverse: 0;
     margin-right: calc(1rem * var(--tw-space-x-reverse));
     margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
-  .md\:p-12{
+  .md\:p-12 {
     padding: 3rem;
   }
 
-  .md\:p-4{
+  .md\:p-4 {
     padding: 1rem;
   }
 
-  .md\:text-2xl{
+  .md\:text-2xl {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 
-  .md\:text-3xl{
+  .md\:text-3xl {
     font-size: 1.875rem;
     line-height: 2.25rem;
   }
 
-  .md\:text-4xl{
+  .md\:text-4xl {
     font-size: 2.25rem;
     line-height: 2.5rem;
   }
 
-  .md\:text-lg{
+  .md\:text-lg {
     font-size: 1.125rem;
     line-height: 1.75rem;
   }
 
-  .md\:text-xl{
+  .md\:text-xl {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
-@media (min-width: 1024px){
+@media (min-width: 1024px) {
 
-  .lg\:col-span-2{
+  .lg\:col-span-2 {
     grid-column: span 2 / span 2;
   }
 
-  .lg\:grid-cols-2{
+  .lg\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .lg\:grid-cols-4{
+  .lg\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
-  .lg\:flex-row{
+  .lg\:flex-row {
     flex-direction: row;
   }
 
-  .lg\:gap-12{
+  .lg\:gap-12 {
     gap: 3rem;
   }
 
-  .lg\:space-y-0 > :not([hidden]) ~ :not([hidden]){
+  .lg\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
     margin-bottom: calc(0px * var(--tw-space-y-reverse));
   }
 
-  .lg\:text-left{
+  .lg\:text-left {
     text-align: left;
   }
 
-  .lg\:text-right{
+  .lg\:text-right {
     text-align: right;
   }
 
-  .lg\:text-5xl{
+  .lg\:text-5xl {
     font-size: 3rem;
     line-height: 1;
   }
 
-  .lg\:text-6xl{
+  .lg\:text-6xl {
     font-size: 3.75rem;
     line-height: 1;
   }

--- a/templates/_partials/header.tpl
+++ b/templates/_partials/header.tpl
@@ -22,6 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
+<link rel="stylesheet" href="{$urls.css_url}header-classic.css" type="text/css" media="all">
 {block name='header_banner'}
   <div class="header-banner">
     {hook h='displayBanner'}


### PR DESCRIPTION
- Extraje los estilos del encabezado del tema Classic a un archivo `header-classic.css`.
- Enlacé `header-classic.css` directamente en `header.tpl` para que solo afecte al encabezado.
- Eliminé la importación global de los estilos de Classic para evitar conflictos.